### PR TITLE
Fix UnityResourceList.first_item issue of host.add_initiator and system.create_host

### DIFF
--- a/storops/exception.py
+++ b/storops/exception.py
@@ -256,7 +256,10 @@ class NoIndexException(StoropsException):
 
 
 class UnityNameNotUniqueError(UnityException):
-    pass
+    def __init__(self, message="multiple objects found", objects=None):
+        super(UnityNameNotUniqueError, self).__init__()
+        self.message = message
+        self.objects = objects
 
 
 class UnityCifsServiceNotEnabledError(UnityException):

--- a/storops/unity/resource/__init__.py
+++ b/storops/unity/resource/__init__.py
@@ -110,7 +110,9 @@ class UnityResource(Resource):
                     '{}:{} not found.'.format(clz_name, name))
             elif len(ret) > 1:
                 raise UnityNameNotUniqueError(
-                    'multiple {} with name {} found.'.format(clz_name, name))
+                    'multiple {} with name {} found.'.format(clz_name, name),
+                    # throw out the found multiple objects for later analysis
+                    objects=ret)
             else:
                 ret = ret[0]
         return ret

--- a/storops/unity/resource/host.py
+++ b/storops/unity/resource/host.py
@@ -130,11 +130,7 @@ class UnityHost(UnityResource):
         initiators = UnityHostInitiatorList.get(cli=self._cli,
                                                 initiator_id=uid)
 
-        # Even if no initiators are found, the initiators object still contain
-        # one fake initiator.
-        initiator = initiators.first_item
-        if not initiator.existed:
-
+        if not initiators:
             # Set the ISCSI or FC type
             if re.match("(\w{2}:){15}\w{2}", uid, re.I):
                 uid_type = HostInitiatorTypeEnum.FC
@@ -152,6 +148,7 @@ class UnityHost(UnityResource):
                     'name {} not found under host {}.'
                     .format(uid, self.name))
         else:
+            initiator = initiators.first_item
             log.debug('initiator {} is existed in unity system.'.format(uid))
 
         initiator.modify(self)

--- a/storops/unity/resource/system.py
+++ b/storops/unity/resource/system.py
@@ -64,17 +64,16 @@ class UnitySystem(UnitySingletonResource):
         return self._get_unity_rsc(UnityStorageProcessorList, _id=_id,
                                    name=name, **filters)
 
-    def get_iscsi_portal(self, _id=None, name=None, **filters):
-        return self._get_unity_rsc(UnityIscsiPortalList, _id=_id,
-                                   name=name, **filters)
+    def get_iscsi_portal(self, _id=None, **filters):
+        return self._get_unity_rsc(UnityIscsiPortalList, _id=_id, **filters)
 
     def get_ethernet_port(self, _id=None, name=None, **filters):
         return self._get_unity_rsc(UnityEthernetPortList, _id=_id,
                                    name=name, **filters)
 
     def create_host(self, name, host_type=None, desc=None, os=None):
-        host = UnityHostList.get(self._cli, name=name).first_item
-        if host and host.existed:
+        host = UnityHostList.get(self._cli, name=name)
+        if host:
             raise ex.UnityHostNameInUseError()
         else:
             host = UnityHost.create(self._cli, name, host_type=host_type,

--- a/storops/unity/resp.py
+++ b/storops/unity/resp.py
@@ -46,8 +46,10 @@ class RestResponse(object):
         if 'entries' in self.body:
             ret = [entry.get('content', {})
                    for entry in self.body['entries']]
+        elif 'content' in self.body:
+            ret = [self.body.get('content')]
         else:
-            ret = [self.body.get('content', {})]
+            ret = []
         return ret
 
     @property

--- a/test/test_exception.py
+++ b/test/test_exception.py
@@ -20,7 +20,8 @@ from unittest import TestCase
 from hamcrest import assert_that, equal_to, raises
 
 from storops.exception import StoropsException, check_error, \
-    VNXSpNotAvailableError, VNXNotSupportedError
+    VNXSpNotAvailableError, VNXNotSupportedError, UnityNameNotUniqueError
+from storops.unity.resource.host import UnityHost
 
 __author__ = 'Cedric Zhuang'
 
@@ -78,3 +79,13 @@ class ExceptionTest(TestCase):
         out = 'The specified source LUN is not currently migrating.'
         # no exception, not checking a `VNXLunNotMigratingError`
         check_error(out, VNXNotSupportedError, VNXSpNotAvailableError)
+
+    def test_unity_name_not_unique_error(self):
+        ex = UnityNameNotUniqueError(objects=None)
+        assert_that(str(ex), equal_to('multiple objects found'))
+        assert_that(ex.objects, equal_to(None))
+
+        host = UnityHost(_id=9999)
+        ex = UnityNameNotUniqueError("Multipath hosts found.", objects=host)
+        assert_that(str(ex), equal_to('Multipath hosts found.'))
+        assert_that(ex.objects, equal_to(host))

--- a/test/unity/resource/test_system.py
+++ b/test/unity/resource/test_system.py
@@ -146,8 +146,7 @@ class UnitySystemTest(TestCase):
         unity = t_unity()
         cp = unity.get_capability_profile(service_levels=[5])
         assert_that(cp, instance_of(UnityCapabilityProfileList))
-        assert_that(len(cp), 1)
-        assert_that(cp[0].existed, equal_to(False))
+        assert_that(len(cp), equal_to(0))
 
     @patch_rest()
     def test_get_sp_by_name(self):


### PR DESCRIPTION
* Fix UnityResourceList.get will return fake object issue.
* Fix system.get_iscsi_portal since there is no 'name' property at all
* Make UnityNameNotUniqueError can return the found objects