### PR TITLE
[GH-10] Add display_name to VNXPort

### DIFF
--- a/storops/vnx/enums.py
+++ b/storops/vnx/enums.py
@@ -83,6 +83,10 @@ class VNXSPEnum(VNXEnum):
     def index(self):
         return self.value.lower()[-1]
 
+    @property
+    def display_name(self):
+        return self.index.upper()
+
 
 class VNXProvisionEnum(VNXEnum):
     # value of spec "provisioning:type"

--- a/storops/vnx/resource/port.py
+++ b/storops/vnx/resource/port.py
@@ -46,6 +46,13 @@ class VNXPort(VNXCliResource):
     def wwn(self):
         return self._get_property('_wwn')
 
+    @property
+    def display_name(self):
+        items = [self.sp.display_name, str(self.port_id)]
+        if self.vport_id is not None:
+            items.append(str(self.vport_id))
+        return '-'.join(items)
+
     def config_ip(self, ip, mask, gateway, vport_id=None, vlan_id=None):
         if self.type != VNXPortType.ISCSI:
             raise TypeError('configure IP only works for iSCSI ports.')

--- a/test/vnx/resource/test_port.py
+++ b/test/vnx/resource/test_port.py
@@ -73,6 +73,7 @@ class VNXSPPortTest(TestCase):
         assert_that(port.logged_in_initiators, equal_to(1))
         assert_that(port.not_logged_in_initiators, equal_to(2))
         assert_that(port.type, equal_to(VNXPortType.FC))
+        assert_that(port.display_name, equal_to('A-0'))
 
     @patch_cli()
     def test_get_port_by_type(self):
@@ -173,6 +174,7 @@ class VNXConnectionPortTest(TestCase):
         assert_that(port.gateway_address, equal_to('0.0.0.0'))
         assert_that(port.type, equal_to(VNXPortType.ISCSI))
         assert_that(port.existed, equal_to(True))
+        assert_that(port.display_name, equal_to('A-4-0'))
 
     @patch_cli()
     def test_get_all(self):


### PR DESCRIPTION
Add property `display_name` to VNXPort and VNXSPEnum.
If you have an `VNXPort` instance, let's say `port`.
Then `port.display_name` will return a string like 'A-0-0' for iSCSI and
'A-1' for FC.