### PR TITLE
[GH-17] Error if vnx domain not configured

### DIFF
--- a/storops/vnx/resource/vnx_domain.py
+++ b/storops/vnx/resource/vnx_domain.py
@@ -20,7 +20,6 @@ import re
 
 from past.builtins import filter
 
-from storops.exception import VNXObjectNotFound
 from storops.lib.converter import to_datetime
 from storops.vnx.enums import VNXSPEnum
 from storops.vnx.resource import VNXCliResourceList, VNXCliResource
@@ -72,8 +71,8 @@ class VNXDomainNodeList(VNXCliResourceList):
                 ret = node
                 break
         else:
-            raise VNXObjectNotFound(
-                'domain node "{}" not found'.format(node_id))
+            log.info('node "{}" not found in the vnx domain.')
+            ret = None
         return ret
 
     @staticmethod
@@ -81,7 +80,7 @@ class VNXDomainNodeList(VNXCliResourceList):
         dnl = VNXDomainNodeList(cli)
         dnl.with_no_poll()
         node = dnl.get_node(serial)
-        if node.control_station is None:
+        if node is None or node.control_station is None:
             log.info('system {} does not has control station.'.format(serial))
             ret = None
         else:

--- a/test/vnx/resource/test_vnx_domain.py
+++ b/test/vnx/resource/test_vnx_domain.py
@@ -17,11 +17,9 @@ from __future__ import unicode_literals
 
 from unittest import TestCase
 
-from hamcrest import assert_that, equal_to, contains_string, is_not, raises, \
-    none
+from hamcrest import assert_that, equal_to, contains_string, is_not, none
 
 from test.vnx.cli_mock import t_cli, patch_cli
-from storops.exception import VNXObjectNotFound
 from storops.vnx.enums import VNXSPEnum
 from storops.vnx.resource.vnx_domain import VNXDomainNodeList, \
     VNXNetworkAdmin, VNXStorageProcessor
@@ -90,11 +88,7 @@ class VNXDomainNodeListTest(TestCase):
 
     @patch_cli
     def test_get_node_not_found(self):
-        def f():
-            node = self.dnl.get_node('abcde')
-            assert_that(len(node.members), equal_to(2))
-
-        assert_that(f, raises(VNXObjectNotFound, 'abcde'))
+        assert_that(self.dnl.get_node('abcde'), none())
 
     @patch_cli
     def test_get_spa_check_ip(self):


### PR DESCRIPTION
When user retrieves the property of a VNX system, an error pops up saying
this vnx node cannot be found in the domain.

It should not be an error because it's a normal configuration.  Use an
info log instead.

When this happens, the control station IP won't be available.