### PR TITLE
Prefer security file over username/password

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ StorOps: The Python Library for VNX & Unity
 .. image:: https://img.shields.io/pypi/v/storops.svg
     :target: https://pypi.python.org/pypi/storops
     
-VERSION: 0.2.18
+VERSION: 0.2.19
 
 A minimalist Python library to manage VNX/Unity systems.
 This document lies in the source code and go with the release.
@@ -311,6 +311,8 @@ EMC Contributors
 
 Community Contributors
 ``````````````````````
+
+- Paulo Matias <matias@ufscar.br>
 
 Patches and Suggestions
 ```````````````````````

--- a/storops/vnx/navi_command.py
+++ b/storops/vnx/navi_command.py
@@ -77,12 +77,11 @@ class NaviCommand(object):
         return self._is_credential_valid
 
     def get_credentials(self):
-        if self._username is None and self._password is None:
+        if self._sec_file is not None:
             # use security file
-            if self._sec_file is not None:
-                ret = text_var('-secfilepath', self._sec_file)
-            else:
-                ret = []
+            ret = text_var('-secfilepath', self._sec_file)
+        elif self._username is None and self._password is None:
+            ret = []
         elif self._username is None or self._password is None:
             self._is_credential_valid = False
             raise ex.VNXCredentialError('username or password missing.')

--- a/test/vnx/test_navi_command.py
+++ b/test/vnx/test_navi_command.py
@@ -45,6 +45,13 @@ class NaviCommandTest(TestCase):
                     equal_to('-secfilepath /a/b/c.key'))
 
     @patch_cli
+    def test_security_file_precedence(self):
+        cmd = NaviCommand(sec_file=r'/a/b/c.key',
+                          username='admin', password='')
+        assert_that(' '.join(cmd.get_credentials()),
+                    equal_to('-secfilepath /a/b/c.key'))
+
+    @patch_cli
     def test_username_password_timeout(self):
         cmd = NaviCommand('a', 'a', 1, timeout=20)
         assert_that(' '.join(map(str, cmd.get_credentials())),


### PR DESCRIPTION
Currently, it is impossible to use the VNX driver in cinder (master branch) with a security file, whereas the old driver (for stable/mitaka) used to work well.

The cause of the issue is as follows

* Storops side:

   * **username** and **password** currently take precedence over **sec_file** if both are defined (*defined* meaning different from None).

* Cinder side:

   * **san_login** and **san_password** have default values (`'admin'` and `''`, respectively):  [cinder/volume/drivers/san/san.py:45](https://github.com/openstack/cinder/blob/9567844f0e180a7278767fdcd4378b19913933be/cinder/volume/drivers/san/san.py#L45)

   * **storage_vnx_security_file_dir** does not have a default value: [cinder/volume/drivers/emc/vnx/common.py:46](https://github.com/openstack/cinder/blob/572b84c073ef66d976d4530d9b7f07f518695ab0/cinder/volume/drivers/emc/vnx/common.py#L46)

   * It is impossible to override **san_login** and **san_password** in such a way to get None as their value.

The proposed fix inverts the precedence in storops. This way, the following configuration in `cinder.conf` works fine:

```ini
[vnx]
storage_vnx_pool_names=Cloud_Pool
volume_backend_name=vnx
naviseccli_path=/opt/Navisphere/bin/naviseccli
volume_driver=cinder.volume.drivers.emc.vnx.driver.EMCVNXDriver
storage_vnx_security_file_dir=/var/lib/cinder
initiator_auto_registration=True
san_ip=172.16.0.102
storage_protocol=iscsi
```

Another possible fix would be to consider empty strings as undefined (i.e. change `if self._username is None and self._password is None` to `if not self._username and not self._password`), but this would make Mitaka's `cinder.conf` even more incompatible with Newton's one, as users would be required to declare **san_login** as an empty string.

Otherwise, things could be fixed at the cinder side, but it feels weird to convert an empty string to None before passing it to a library. On the other hand, removing default values for **san_login** and **san_password** could have implications for users of other storage backends.