### PR TITLE
[GH-38] UnityLun expand support.

### DIFF
--- a/storops/exception.py
+++ b/storops/exception.py
@@ -286,9 +286,23 @@ class UnityHostNameInUseError(UnityException):
     pass
 
 
+class UnityLunException(UnityException):
+    pass
+
+
 @rest_exception
-class UnityLunNameInUseError(UnityException):
+class UnityLunNameInUseError(UnityLunException):
     error_code = 108007744
+
+
+@rest_exception
+class UnityLunShrinkNotSupportedError(UnityLunException):
+    error_code = 108007728
+
+
+@rest_exception
+class UnityNothingToModifyError(UnityException):
+    error_code = 108007456
 
 
 @rest_exception

--- a/storops/unity/resource/lun.py
+++ b/storops/unity/resource/lun.py
@@ -83,6 +83,10 @@ class UnityLun(UnityResource):
     def total_size_gb(self):
         return self.size_total / (1024 ** 3)
 
+    @total_size_gb.setter
+    def total_size_gb(self, value):
+        self.expand(value * 1024 ** 3)
+
     @property
     def max_iops(self):
         return self.effective_io_limit_max_iops
@@ -90,6 +94,17 @@ class UnityLun(UnityResource):
     @property
     def max_kbps(self):
         return self.effective_io_limit_max_kbps
+
+    def expand(self, new_size):
+        """ expand the LUN to a new size
+
+        :param new_size: new size in bytes.
+        :return: the old size
+        """
+        ret = self.size_total
+        resp = self.modify(size=new_size)
+        resp.raise_if_err()
+        return ret
 
     @staticmethod
     def _compose_lun_parameter(cli, **kwargs):

--- a/test/unity/rest_data/storageResource/does_not_support_shrink.json
+++ b/test/unity/rest_data/storageResource/does_not_support_shrink.json
@@ -1,0 +1,12 @@
+{
+  "error": {
+    "errorCode": 108007728,
+    "httpStatusCode": 422,
+    "messages": [
+      {
+        "en-US": "The system does not support shrink operation for LUNs of this type. (Error Code:0x6701130)"
+      }
+    ],
+    "created": "2016-10-28T07:00:33.186Z"
+  }
+}

--- a/test/unity/rest_data/storageResource/index.json
+++ b/test/unity/rest_data/storageResource/index.json
@@ -662,6 +662,33 @@
         "name": "Himalia"
       },
       "response": "create_lun_sv_2026.json"
+    },
+    {
+      "url": "/api/instances/storageResource/sv_2/action/modifyLun?compact=True",
+      "body": {
+        "lunParameters": {
+          "size": 108447924224
+        }
+      },
+      "response": "empty.json"
+    },
+    {
+      "url": "/api/instances/storageResource/sv_2/action/modifyLun?compact=True",
+      "body": {
+        "lunParameters": {
+          "size": 1073741824
+        }
+      },
+      "response": "does_not_support_shrink.json"
+    },
+    {
+      "url": "/api/instances/storageResource/sv_2/action/modifyLun?compact=True",
+      "body": {
+        "lunParameters": {
+          "size": 107374182400
+        }
+      },
+      "response": "nothing_to_modify.json"
     }
   ]
 }

--- a/test/unity/rest_data/storageResource/nothing_to_modify.json
+++ b/test/unity/rest_data/storageResource/nothing_to_modify.json
@@ -1,0 +1,12 @@
+{
+  "error": {
+    "errorCode": 108007456,
+    "httpStatusCode": 409,
+    "messages": [
+      {
+        "en-US": "The user requested modification of the storage resource but the system found that there is nothing to modify. (Error Code:0x6701020)"
+      }
+    ],
+    "created": "2016-10-28T07:20:00.489Z"
+  }
+}


### PR DESCRIPTION
Support expansion of Unity LUN.
Shrink is not supported.

Add error code for situations when new size is:
- smaller than current size.
- equal to current size.
