### PR TITLE
Add missing keep_for parameter for snap operations

### DIFF
--- a/storops/exception.py
+++ b/storops/exception.py
@@ -737,6 +737,12 @@ class VNXLunHasSnapMountPointError(VNXDeleteLunError):
 
 
 @cli_exception
+class VNXLunHasSnapError(VNXDeleteLunError):
+    error_message = ("The LUN cannot be destroyed because it still"
+                     " has snapshots")
+
+
+@cli_exception
 class VNXLunUsedByFeatureError(VNXDeleteLunError):
     error_message = ("Cannot unbind LUN because it's being used by a"
                      " feature of the Storage System")

--- a/storops/vnx/resource/lun.py
+++ b/storops/vnx/resource/lun.py
@@ -163,9 +163,10 @@ class VNXLun(VNXCliResource):
         ret.poll = poll
         return ret
 
-    def create_snap(self, name, allow_rw=None, auto_delete=None):
+    def create_snap(self, name, allow_rw=None, auto_delete=None,
+                    keep_for=None):
         return VNXSnap.create(self._cli, self.get_id(self), name, allow_rw,
-                              auto_delete)
+                              auto_delete, keep_for)
 
     def attach_snap(self, snap):
         snap_name = VNXSnap.get_name(snap)

--- a/storops/vnx/resource/snap.py
+++ b/storops/vnx/resource/snap.py
@@ -44,8 +44,9 @@ class VNXSnap(VNXCliResource):
         self._name = name
 
     @classmethod
-    def create(cls, cli, res, name, allow_rw=None, auto_delete=None):
-        out = cli.create_snap(res, name, allow_rw, auto_delete)
+    def create(cls, cli, res, name, allow_rw=None, auto_delete=None,
+               keep_for=None):
+        out = cli.create_snap(res, name, allow_rw, auto_delete, keep_for)
         msg = 'failed to create snap "{}" for {}'.format(name, res)
         ex.raise_if_err(out, msg, default=ex.VNXCreateSnapError)
         return VNXSnap(name, cli=cli)


### PR DESCRIPTION
Add keep_for parameter in lun.create_snap and snap.create interfaces