### PR TITLE
[GH-74] Auto balance SP to create NAS server

### DIFF
--- a/storops/lib/resource.py
+++ b/storops/lib/resource.py
@@ -197,10 +197,19 @@ class ResourceList(Resource):
         super(ResourceList, self).__init__()
         self._list = None
 
-    def shadow_copy(self):
+    def shadow_copy(self, *args, **kwargs):
         ret = super(ResourceList, self).shadow_copy()
         ret._list = self._list
+        ret.set_filter(*args, **kwargs)
         return ret
+
+    def set_filter(self, *args, **kwargs):
+        self._set_filter(*args, **kwargs)
+        self._apply_filter()
+
+    def _set_filter(self, *args, **kwargs):
+        # implemented by child classes if needed
+        pass
 
     @classmethod
     def get_rsc_clz_list(cls, rsc_list_collection):

--- a/storops/unity/resource/__init__.py
+++ b/storops/unity/resource/__init__.py
@@ -112,8 +112,9 @@ class UnityResource(Resource):
                     len(self.get_preloaded_prop_keys()) > 1)
             else:
                 # Return False when only id is parsed
-                ret = not (len(self._parsed_resource) == 1 and
-                           len(self.property_names()) > 1)
+                ret = not (self.parsed_resource is None or
+                           (len(self._parsed_resource) == 1 and
+                            len(self.property_names()) > 1))
         return ret
 
     def _get_properties(self, dec=0):

--- a/storops/unity/resource/nas_server.py
+++ b/storops/unity/resource/nas_server.py
@@ -142,6 +142,25 @@ class UnityNasServer(UnityResource):
 
 
 class UnityNasServerList(UnityResourceList):
+    def __init__(self, cli=None, home_sp=None, current_sp=None, **filters):
+        super(UnityNasServerList, self).__init__(cli, **filters)
+        self._home_sp_id = None
+        self._current_sp_id = None
+        self._set_filter(home_sp, current_sp)
+
+    def _set_filter(self, home_sp=None, current_sp=None, **kwargs):
+        self._home_sp_id, self._current_sp_id = (
+            [sp.get_id() if isinstance(sp, UnityStorageProcessor)
+             else sp for sp in (home_sp, current_sp)])
+
+    def _filter(self, nas_server):
+        ret = True
+        if self._home_sp_id is not None:
+            ret &= nas_server.home_sp.get_id() == self._home_sp_id
+        if self._current_sp_id is not None:
+            ret &= nas_server.current_sp.get_id() == self._current_sp_id
+        return ret
+
     @classmethod
     def get_resource_class(cls):
         return UnityNasServer

--- a/storops/vnx/resource/__init__.py
+++ b/storops/vnx/resource/__init__.py
@@ -169,17 +169,9 @@ class VNXCliResourceList(VNXCliResource, ResourceList):
         self._poll = True
 
     def shadow_copy(self, *args, **kwargs):
-        ret = super(VNXCliResourceList, self).shadow_copy()
+        ret = VNXCliResource.shadow_copy(self)
         ret.set_filter(*args, **kwargs)
         return ret
-
-    def set_filter(self, *args, **kwargs):
-        self._set_filter(*args, **kwargs)
-        self._apply_filter()
-
-    def _set_filter(self, *args, **kwargs):
-        # implemented by child classes if needed
-        pass
 
     @classmethod
     def _get_parser(cls):

--- a/test/unity/resource/test_nas_server.py
+++ b/test/unity/resource/test_nas_server.py
@@ -192,3 +192,17 @@ class UnityNasServerTest(TestCase):
                                        local_password='Password123!')
 
         assert_that(f, raises(UnitySmbNameInUseError, 'name already exists'))
+
+    @patch_rest
+    def test_shadow_copy_home_sp(self):
+        nas_servers = UnityNasServerList(cli=t_rest(), home_sp='spa')
+        assert_that(len(nas_servers), equal_to(2))
+        nas_servers = UnityNasServerList(cli=t_rest(), home_sp='spb')
+        assert_that(len(nas_servers), equal_to(1))
+
+    @patch_rest
+    def test_shadow_copy_current_sp(self):
+        nas_servers = UnityNasServerList(cli=t_rest(), current_sp='spa')
+        assert_that(len(nas_servers), equal_to(1))
+        nas_servers = UnityNasServerList(cli=t_rest(), current_sp='spb')
+        assert_that(len(nas_servers), equal_to(2))

--- a/test/unity/resource/test_system.py
+++ b/test/unity/resource/test_system.py
@@ -272,6 +272,36 @@ class UnitySystemTest(TestCase):
         assert_that(nas_server.existed, equal_to(True))
 
     @patch_rest
+    def test_auto_balance_sp_one_sp(self):
+        unity = t_unity()
+
+        @patch_rest(output='auto_balance_sp_one_sp.json')
+        def inner():
+            sp = unity._auto_balance_sp()
+            assert_that(sp.get_id(), equal_to('spa'))
+
+        unity._auto_balance_sp()
+        inner()
+
+    @patch_rest
+    def test_auto_balance_sp_to_spb(self):
+        unity = t_unity()
+        sp = unity._auto_balance_sp()
+        assert_that(sp.get_id(), equal_to('spb'))
+
+    @patch_rest
+    def test_auto_balance_sp_to_spa(self):
+        unity = t_unity()
+
+        @patch_rest(output='auto_balance_sp_to_spa.json')
+        def inner():
+            sp = unity._auto_balance_sp()
+            assert_that(sp.get_id(), equal_to('spa'))
+
+        unity._auto_balance_sp()
+        inner()
+
+    @patch_rest
     def test_get_ip_ports(self):
         unity = t_unity()
         ip_ports = unity.get_ip_port()

--- a/test/unity/rest_data/nasServer/auto_balance_sp_one_sp.json
+++ b/test/unity/rest_data/nasServer/auto_balance_sp_one_sp.json
@@ -92,40 +92,7 @@
           "id": "spa"
         },
         "currentSP": {
-          "id": "spb"
-        }
-      }
-    },
-    {
-      "content": {
-        "id": "system_nas_1",
-        "replicationType": 0,
-        "type": 64,
-        "currentUnixDirectoryService": 0,
-        "instanceId": "root/emc:EMC_UEM_FileServerContainerLeaf%InstanceID=system_nas_1",
-        "objectId": 103079215106,
-        "name": "SVDM_B",
-        "health": {
-          "value": 5,
-          "descriptionIds": [
-            "ALRT_COMPONENT_OK"
-          ],
-          "descriptions": [
-            "The component is operating normally. No action is required."
-          ]
-        },
-        "sizeAllocated": 2684354560,
-        "isSystem": true,
-        "isReplicationEnabled": false,
-        "isReplicationDestination": false,
-        "isMultiProtocolEnabled": false,
-        "credentialsCacheTTL": "00:20:00.000",
-        "isExtendedUnixCredentialEnabled": false,
-        "homeSP": {
-          "id": "spb"
-        },
-        "currentSP": {
-          "id": "spb"
+          "id": "spa"
         }
       }
     }

--- a/test/unity/rest_data/nasServer/auto_balance_sp_to_spa.json
+++ b/test/unity/rest_data/nasServer/auto_balance_sp_to_spa.json
@@ -65,6 +65,116 @@
     },
     {
       "content": {
+        "id": "nas_2",
+        "replicationType": 0,
+        "type": 64,
+        "currentUnixDirectoryService": 0,
+        "instanceId": "root/emc:EMC_UEM_FileServerContainerLeaf%InstanceID=nas_2",
+        "objectId": 103079215108,
+        "name": "esa_nasserver",
+        "health": {
+          "value": 5,
+          "descriptionIds": [
+            "ALRT_COMPONENT_OK"
+          ],
+          "descriptions": [
+            "The component is operating normally. No action is required."
+          ]
+        },
+        "sizeAllocated": 2952790016,
+        "isSystem": false,
+        "isReplicationEnabled": false,
+        "isReplicationDestination": false,
+        "isMultiProtocolEnabled": false,
+        "credentialsCacheTTL": "00:15:00.000",
+        "isExtendedUnixCredentialEnabled": false,
+        "homeSP": {
+          "id": "spb"
+        },
+        "currentSP": {
+          "id": "spb"
+        },
+        "pool": {
+          "id": "pool_1"
+        },
+        "cifsServer": [
+          {
+            "id": "cifs_1"
+          }
+        ],
+        "fileDNSServer": {
+          "id": "dns_1"
+        },
+        "fileInterface": [
+          {
+            "id": "if_5"
+          }
+        ],
+        "preferredInterfaceSettings": {
+          "id": "preferred_if_1"
+        },
+        "virusChecker": {
+          "id": "cava_1"
+        }
+      }
+    },
+    {
+      "content": {
+        "id": "nas_3",
+        "replicationType": 0,
+        "type": 64,
+        "currentUnixDirectoryService": 0,
+        "instanceId": "root/emc:EMC_UEM_FileServerContainerLeaf%InstanceID=nas_3",
+        "objectId": 103079215109,
+        "name": "esa_nasserver",
+        "health": {
+          "value": 5,
+          "descriptionIds": [
+            "ALRT_COMPONENT_OK"
+          ],
+          "descriptions": [
+            "The component is operating normally. No action is required."
+          ]
+        },
+        "sizeAllocated": 2952790016,
+        "isSystem": false,
+        "isReplicationEnabled": false,
+        "isReplicationDestination": false,
+        "isMultiProtocolEnabled": false,
+        "credentialsCacheTTL": "00:15:00.000",
+        "isExtendedUnixCredentialEnabled": false,
+        "homeSP": {
+          "id": "spb"
+        },
+        "currentSP": {
+          "id": "spb"
+        },
+        "pool": {
+          "id": "pool_1"
+        },
+        "cifsServer": [
+          {
+            "id": "cifs_1"
+          }
+        ],
+        "fileDNSServer": {
+          "id": "dns_1"
+        },
+        "fileInterface": [
+          {
+            "id": "if_5"
+          }
+        ],
+        "preferredInterfaceSettings": {
+          "id": "preferred_if_1"
+        },
+        "virusChecker": {
+          "id": "cava_1"
+        }
+      }
+    },
+    {
+      "content": {
         "id": "system_nas_0",
         "replicationType": 0,
         "type": 64,
@@ -92,7 +202,7 @@
           "id": "spa"
         },
         "currentSP": {
-          "id": "spb"
+          "id": "spa"
         }
       }
     },

--- a/test/unity/rest_data/storageProcessor/auto_balance_sp_one_sp.json
+++ b/test/unity/rest_data/storageProcessor/auto_balance_sp_one_sp.json
@@ -1,0 +1,53 @@
+{
+  "@base": "https://10.244.223.66/api/types/storageProcessor/instances?fields=biosFirmwareRevision,emcPartNumber,emcSerialNumber,health,id,instanceId,isRescueMode,manufacturer,memorySize,model,name,needsReplacement,operationalStatus,parent,postFirmwareRevision,sasExpanderVersion,slotNumber,vendorPartNumber,vendorSerialNumber,parentDpe.id&per_page=2000&compact=true",
+  "updated": "2016-03-16T03:43:30.538Z",
+  "links": [
+    {
+      "rel": "self",
+      "href": "&page=1"
+    }
+  ],
+  "entries": [
+    {
+      "content": {
+        "id": "spa",
+        "operationalStatus": [
+          32771,
+          32832,
+          32834
+        ],
+        "instanceId": "root/emc:EMC_UEM_StorageProcessorLeaf%Tag=06:00:00:00:05:00:00:00:00:00:00:00:00:00:00:02",
+        "parent": {
+          "id": "dpe",
+          "resource": "dpe"
+        },
+        "health": {
+          "value": 5,
+          "descriptionIds": [
+            "ALRT_COMPONENT_OK"
+          ],
+          "descriptions": [
+            "The component is operating normally. No action is required."
+          ]
+        },
+        "needsReplacement": false,
+        "isRescueMode": false,
+        "model": "OBERON CANISTER 10C 105W 2.6G",
+        "slotNumber": 0,
+        "name": "SP A",
+        "emcPartNumber": "110-297-008C-04",
+        "emcSerialNumber": "CF2HF150300001",
+        "manufacturer": "",
+        "vendorPartNumber": "",
+        "vendorSerialNumber": "",
+        "sasExpanderVersion": "2.7.1",
+        "biosFirmwareRevision": "30.89",
+        "postFirmwareRevision": "21.2",
+        "memorySize": 65536,
+        "parentDpe": {
+          "id": "dpe"
+        }
+      }
+    }
+  ]
+}

--- a/test/unity/rest_data/storageProcessor/auto_balance_sp_to_spa.json
+++ b/test/unity/rest_data/storageProcessor/auto_balance_sp_to_spa.json
@@ -1,0 +1,93 @@
+{
+  "@base": "https://10.244.223.66/api/types/storageProcessor/instances?fields=biosFirmwareRevision,emcPartNumber,emcSerialNumber,health,id,instanceId,isRescueMode,manufacturer,memorySize,model,name,needsReplacement,operationalStatus,parent,postFirmwareRevision,sasExpanderVersion,slotNumber,vendorPartNumber,vendorSerialNumber,parentDpe.id&per_page=2000&compact=true",
+  "updated": "2016-03-16T03:43:30.538Z",
+  "links": [
+    {
+      "rel": "self",
+      "href": "&page=1"
+    }
+  ],
+  "entries": [
+    {
+      "content": {
+        "id": "spa",
+        "operationalStatus": [
+          32771,
+          32832,
+          32834
+        ],
+        "instanceId": "root/emc:EMC_UEM_StorageProcessorLeaf%Tag=06:00:00:00:05:00:00:00:00:00:00:00:00:00:00:02",
+        "parent": {
+          "id": "dpe",
+          "resource": "dpe"
+        },
+        "health": {
+          "value": 5,
+          "descriptionIds": [
+            "ALRT_COMPONENT_OK"
+          ],
+          "descriptions": [
+            "The component is operating normally. No action is required."
+          ]
+        },
+        "needsReplacement": false,
+        "isRescueMode": false,
+        "model": "OBERON CANISTER 10C 105W 2.6G",
+        "slotNumber": 0,
+        "name": "SP A",
+        "emcPartNumber": "110-297-008C-04",
+        "emcSerialNumber": "CF2HF150300001",
+        "manufacturer": "",
+        "vendorPartNumber": "",
+        "vendorSerialNumber": "",
+        "sasExpanderVersion": "2.7.1",
+        "biosFirmwareRevision": "30.89",
+        "postFirmwareRevision": "21.2",
+        "memorySize": 65536,
+        "parentDpe": {
+          "id": "dpe"
+        }
+      }
+    },
+    {
+      "content": {
+        "id": "spb",
+        "operationalStatus": [
+          32832,
+          32834
+        ],
+        "instanceId": "root/emc:EMC_UEM_StorageProcessorLeaf%Tag=06:00:00:00:05:00:00:00:01:00:00:01:01:00:00:02",
+        "parent": {
+          "id": "dpe",
+          "resource": "dpe"
+        },
+        "health": {
+          "value": 5,
+          "descriptionIds": [
+            "ALRT_COMPONENT_OK"
+          ],
+          "descriptions": [
+            "The component is operating normally. No action is required."
+          ]
+        },
+        "needsReplacement": false,
+        "isRescueMode": false,
+        "model": "OBERON CANISTER 10C 105W 2.6G",
+        "slotNumber": 1,
+        "name": "SP B",
+        "emcPartNumber": "110-297-008C-04",
+        "emcSerialNumber": "CF2HF150500023",
+        "manufacturer": "",
+        "vendorPartNumber": "",
+        "vendorSerialNumber": "",
+        "sasExpanderVersion": "2.7.1",
+        "biosFirmwareRevision": "30.89",
+        "postFirmwareRevision": "21.2",
+        "memorySize": 65536,
+        "parentDpe": {
+          "id": "dpe"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
The current implementation is that: if SP is not passed in (is None) to
create NAS server, storops will use the first item of SP list.

This feature is to auto balance the SP of creating NAS server when SP
is not passed in. SPB will be chosen only when the existing NAS servers
on SPA are more than the ones on SPB. Otherwise, SPA will be chosen.