### PR TITLE
[GH-76] Remove cobertura and lxml dependency

### DIFF
--- a/storops/vnx/xmlapi.py
+++ b/storops/vnx/xmlapi.py
@@ -53,7 +53,7 @@ class XmlBuilder(object):
 
 _xb = XmlBuilder()
 _default_task_timeout = 5 * 60
-xml_ns = 'http://www.emc.com/schemas/celerra/xml_api'
+XML_NS = 'http://www.emc.com/schemas/celerra/xml_api'
 
 
 class NasXmlBuilder(object):
@@ -61,13 +61,13 @@ class NasXmlBuilder(object):
     @staticmethod
     def query_package(body):
         return _xb.RequestPacket(_xb.Request(_xb.Query(body)),
-                                 xmlns=xml_ns)
+                                 xmlns=XML_NS)
 
     @staticmethod
     def task_package(body):
         return _xb.RequestPacket(
             _xb.Request(_xb.StartTask(body, timeout=_default_task_timeout)),
-            xmlns=xml_ns)
+            xmlns=XML_NS)
 
     @classmethod
     def get_filesystem(cls, name=None, fs_id=None):

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,6 +7,5 @@ pytest-cov>=2.1.0
 pytest-xdist>=1.13.1
 pytest-capturelog>=0.7
 xmltodict>=0.9.2
-cobertura-clover-transform>=1.1.4
 fasteners>=0.12.0
 ddt>=1.0.1 # MIT

--- a/test/vnx/nas_mock.py
+++ b/test/vnx/nas_mock.py
@@ -21,17 +21,21 @@ import os
 
 import six
 import xmltodict as xmltodict
-from lxml import etree
+import xml.etree.ElementTree as ET
 from mock import patch
 
 from storops.lib.common import cache, allow_omit_parentheses
 from storops.vnx.nas_client import VNXNasClient
+from storops.vnx.xmlapi import XML_NS
 from test.utils import ConnectorMock, read_test_file
 from test.vnx.cli_mock import MockCli
 
 __author__ = 'Cedric Zhuang'
 
 log = logging.getLogger(__name__)
+
+
+ET.register_namespace('', XML_NS)
 
 
 @cache
@@ -52,7 +56,7 @@ class MockXmlPost(ConnectorMock):
 
         ret = [cls.base_folder]
         # get two levels after Request
-        node = etree.fromstring(body.encode('utf-8'))
+        node = ET.fromstring(body.encode('utf-8'))
         while len(ret) < 3:
             tag = cls.delete_ns(node.tag)
             if tag in skipped_nodes:
@@ -82,7 +86,7 @@ class MockXmlPost(ConnectorMock):
     @classmethod
     def get_filename(cls, body):
         xml_string = cls.read_index(cls.get_folder(body))
-        indices = etree.fromstring(xml_string.encode('utf-8'))
+        indices = ET.fromstring(xml_string.encode('utf-8'))
         ret = None
         for index in indices:
             for request_packet in index:
@@ -210,9 +214,9 @@ def xml_compare(a, b):
     :param b: xml to compare
     """
     if not isinstance(a, six.string_types):
-        a = etree.tostring(a)
+        a = ET.tostring(a, encoding='utf-8').decode('utf-8')
     if not isinstance(b, six.string_types):
-        b = etree.tostring(b)
+        b = ET.tostring(b, encoding='utf-8').decode('utf-8')
     a = normalise_dict(xmltodict.parse(a))
     b = normalise_dict(xmltodict.parse(b))
     return a == b

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ deps =
 
 commands =
     py.test {posargs} -n2 --cov=storops --cov-config coverage.ini  --cov-report=xml --cov-report term --junit-xml=junit-result.xml test
-    cobertura-clover-transform coverage.xml -o clover.xml
 
 setenv =
     STATICBUILD = true
@@ -30,25 +29,21 @@ commands =
 # all component tests
 commands =
     py.test -n2 --cov=storops --cov-config coverage.ini  --cov-report=xml --cov-report term --junit-xml=junit-result.xml comptest
-    cobertura-clover-transform coverage.xml -o clover.xml
 
 
 [testenv:vnx]
 # component test for vnx platform
 commands =
     py.test -n2 --cov=storops --cov-config coverage.ini  --cov-report=xml --cov-report term --junit-xml=junit-result.xml comptest/vnx
-    cobertura-clover-transform coverage.xml -o clover.xml
 
 
 [testenv:unity]
 # component test for unity platform
 commands =
     py.test -n2 --cov=storops --cov-config coverage.ini  --cov-report=xml --cov-report term --junit-xml=junit-result.xml comptest/unity
-    cobertura-clover-transform coverage.xml -o clover.xml
 
 
 [testenv:vnx_multi]
 # component for VNX features that requires more than 1 array
 commands =
     py.test --cov=storops --cov-config coverage.ini  --cov-report=xml --cov-report term --junit-xml=junit-result.xml comptest/vnx/test_mirror_view.py
-    cobertura-clover-transform coverage.xml -o clover.xml


### PR DESCRIPTION
- Remove cobertura-clover-transform from test-requirements.
- Remove lxml dependency from VNX file UT.