### PR TITLE
[GH-78] Python 3.6 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
     - "2.7"
     - "3.4"
     - "3.5"
+    - "3.6"
 install:
     - pip install coveralls
     - pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-enum34>=1.0.4
 future>=0.15.1
 paramiko>=1.13.0
 python-dateutil>=2.4.2

--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,13 @@
 #    under the License.
 
 from __future__ import unicode_literals
-from setuptools import setup, find_packages
+
 import io
 import os
 import re
+import sys
+
+from setuptools import setup, find_packages
 
 __author__ = 'Cedric Zhuang'
 
@@ -51,6 +54,12 @@ def read_requirements(filename):
         return f.read().splitlines()
 
 
+def install_requirements(filename):
+    packages = read_requirements(filename)
+    if sys.version_info < (3, 4):
+        packages.append("enum34>=1.0.4")
+
+
 def get_description():
     return "Python API for VNX and Unity."
 
@@ -77,6 +86,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         "Natural Language :: English",
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,pep8
+envlist = py27,py34,py35,py36,pep8
 
 
 [testenv]


### PR DESCRIPTION
Add python 3.6 check for CI and tox.

Fix following issue:
  * The `enum34` package creates dependency errors on python 3.6 due to the missing of `IntFlag`.
    Change `setup.py` to only include this package when the python version is lower than 3.4.
