### PR TITLE
[GH 82] Get file port

### DIFF
--- a/storops/lib/resource.py
+++ b/storops/lib/resource.py
@@ -303,7 +303,7 @@ class ResourceList(Resource):
 
     def __add__(self, other):
         if not isinstance(other, ResourceList):
-            raise TypeError
+            raise TypeError('Unsupported type {}'.format(type(other)))
         return self.list + other.list
 
 

--- a/storops/unity/resource/port.py
+++ b/storops/unity/resource/port.py
@@ -23,7 +23,7 @@ from storops.unity.resource import UnityResource, UnityResourceList, \
 from storops.exception import UnityEthernetPortMtuSizeNotSupportError
 from storops.exception import UnityEthernetPortSpeedNotSupportError
 from storops.unity.enums import EPSpeedValuesEnum, IOLimitPolicyTypeEnum
-
+from storops.lib.version import version
 
 __author__ = 'Jay Xu'
 
@@ -36,9 +36,16 @@ class UnityIpPort(UnityResource):
         port.modify(mtu=mtu)
 
     @instance_cache
+    @version('>=4.1')
     def is_link_aggregation(self):
         port = UnityLinkAggregation.get(self._cli, self.get_id())
         return port.existed
+
+    @instance_cache  # noqa
+    @version('<4.1')
+    def is_link_aggregation(self):
+        # Link aggregation is not supported before Falcon 4.1
+        return False
 
     def get_physical_port(self):
         """Returns the link aggregation object or the ethernet port object."""
@@ -237,6 +244,7 @@ class UnityEthernetPortList(UnityResourceList):
         return UnityEthernetPort
 
 
+@version(">=4.1")
 class UnityLinkAggregation(UnityResource):
     @classmethod
     def create(cls, cli, ports, mtu=None):
@@ -260,6 +268,7 @@ class UnityLinkAggregation(UnityResource):
         resp.raise_if_err()
 
 
+@version(">=4.1")
 class UnityLinkAggregationList(UnityResourceList):
     @classmethod
     def get_resource_class(cls):

--- a/storops/unity/resource/system.py
+++ b/storops/unity/resource/system.py
@@ -148,6 +148,25 @@ class UnitySystem(UnitySingletonResource):
         return self._get_unity_rsc(UnityIpPortList, _id=_id, name=name,
                                    **filters)
 
+    @version(">=4.1")
+    def get_file_port(self):
+        """Returns ports list can be used by File
+
+        File ports includes ethernet ports and link aggregation ports.
+        """
+        eths = self.get_ethernet_port()
+        las = self.get_link_aggregation()
+        return eths + las
+
+    @version("<4.1")   # noqa
+    def get_file_port(self):
+        """Returns ports list can be used by File
+
+        File ports includes ethernet ports and link aggregation ports.
+        """
+        eths = self.get_ethernet_port()
+        return eths.list
+
     def get_file_interface(self, _id=None, name=None, **filters):
         return self._get_unity_rsc(UnityFileInterfaceList, _id=_id, name=name,
                                    **filters)
@@ -281,6 +300,7 @@ class UnitySystem(UnitySingletonResource):
     def info(self):
         return UnityBasicSystemInfo.get(cli=self._cli)
 
+    @version('>=4.1')
     def get_link_aggregation(self, _id=None, name=None, **filters):
         return self._get_unity_rsc(UnityLinkAggregationList, _id=_id,
                                    name=name,

--- a/test/unity/resource/test_port.py
+++ b/test/unity/resource/test_port.py
@@ -23,6 +23,7 @@ from hamcrest import assert_that, equal_to, instance_of, only_contains, \
 from storops.exception import UnityEthernetPortSpeedNotSupportError, \
     UnityEthernetPortMtuSizeNotSupportError, UnityResourceNotFoundError, \
     UnityPolicyNameInUseError, UnityEthernetPortAlreadyAggregatedError
+from storops.exception import SystemAPINotSupported
 from storops.unity.enums import ConnectorTypeEnum, EPSpeedValuesEnum, \
     FcSpeedEnum, IOLimitPolicyStateEnum
 from storops.unity.resource.lun import UnityLun
@@ -58,6 +59,11 @@ class UnityIpPortTest(TestCase):
         assert_that(port.is_link_aggregation(), equal_to(False))
         port = UnityIpPort('spa_la_2', cli=t_rest())
         assert_that(port.is_link_aggregation(), equal_to(True))
+
+    @patch_rest
+    def test_is_link_aggregation_not_supported(self):
+        port = UnityIpPort('spa_eth6', cli=t_rest("4.0"))
+        assert_that(port.is_link_aggregation(), equal_to(False))
 
     @patch_rest
     def test_set_mtu_on_eth_port(self):
@@ -359,3 +365,9 @@ class UnityLinkAggregationTest(TestCase):
         la.modify(mtu=1500,
                   remove_ports=[UnityEthernetPort.get(t_rest(), "spa_eth2")],
                   add_ports=[UnityEthernetPort.get(t_rest(), "spa_eth4")])
+
+    @patch_rest()
+    def test_list_la_unsupported(self):
+        def f():
+            UnityLinkAggregation.get(t_rest("4.0.0"))
+        assert_that(f, raises(SystemAPINotSupported))

--- a/test/unity/resource/test_system.py
+++ b/test/unity/resource/test_system.py
@@ -548,6 +548,18 @@ class UnitySystemTest(TestCase):
         assert_that(cg.id, equal_to('spa_la_2'))
 
     @patch_rest
+    def test_get_file_port(self):
+        unity = UnitySystem(cli=t_rest("4.1.0"))
+        ports = unity.get_file_port()
+        assert_that(len(ports), equal_to(10))
+
+    @patch_rest
+    def test_get_file_port_la_unsupported(self):
+        unity = UnitySystem(cli=t_rest("4.0.0"))
+        ports = unity.get_file_port()
+        assert_that(len(ports), equal_to(8))
+
+    @patch_rest
     def test_enable_performance_statistics(self):
         unity = UnitySystem('10.244.223.61')
         assert_that(unity.is_perf_stats_enabled(), equal_to(False))


### PR DESCRIPTION
Add and an API get file port to return ethernet port and link aggregations.
For pre-Falcon release, only return ethernet ports.