### PR TITLE
[GH-84] Error parsing VNX storage group output.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ StorOps: The Python Library for VNX & Unity
 .. image:: https://landscape.io/github/emc-openstack/storops/master/landscape.svg?style=flat
     :target: https://landscape.io/github/emc-openstack/storops/
 
-VERSION: 0.4.3
+VERSION: 0.4.4
 
 A minimalist Python library to manage VNX/Unity systems.
 This document lies in the source code and go with the release.

--- a/storops/vnx/parser_configs.yaml
+++ b/storops/vnx/parser_configs.yaml
@@ -461,7 +461,7 @@ VNXStorageGroupHBA:
   data_src: cli
   properties:
     - label:  |
-        ^\s*(\S+)\s+(SP \w)\s+(\d+)\s*$
+        ^\s*(\S+)\s*(SP \w)\s*(\d+)\s*$
       is_index: True
       is_regex: True
       key: hba

--- a/test/vnx/resource/test_sg.py
+++ b/test/vnx/resource/test_sg.py
@@ -109,6 +109,35 @@ class VNXStorageGroupTest(TestCase):
         assert_that(sg.existed, equal_to(True))
 
     @patch_cli
+    def test_missing_two_tab(self):
+        sg = VNXStorageGroup(name='a.b.c', cli=t_cli())
+        assert_that(len(sg.alu_hlu_map), equal_to(1))
+        assert_that(len(sg.hba_sp_pairs), equal_to(4))
+        uid = 'iqn.1994-05.com.abcdef:ghijk2-l-mn-opq-2.rstuvw.xyz:c3bf2f4cca'
+        port = list(filter(lambda i: i[0] == uid, sg.hba_port_list))[0][1]
+        assert_that(port.sp, equal_to(VNXSPEnum.SP_A))
+        assert_that(port.port_id, equal_to(1))
+        assert_that(port.host_initiator_list, has_item(uid))
+
+    @patch_cli
+    def test_missing_left_tab(self):
+        sg = VNXStorageGroup(name='a.b.c', cli=t_cli())
+        uid = 'iqn.1994-05.com.abcdef:ghijk2-l-mn-opq-2.rstuvw.xyz:c3bf2f4ccb'
+        port = list(filter(lambda i: i[0] == uid, sg.hba_port_list))[0][1]
+        assert_that(port.sp, equal_to(VNXSPEnum.SP_B))
+        assert_that(port.port_id, equal_to(1))
+        assert_that(port.host_initiator_list, has_item(uid))
+
+    @patch_cli
+    def test_missing_right_tab(self):
+        sg = VNXStorageGroup(name='a.b.c', cli=t_cli())
+        uid = 'iqn.1994-05.com.abcdef:ghijk2-l-mn-opq-2.rstuvw.xyz:c3bf2f4ccc'
+        port = list(filter(lambda i: i[0] == uid, sg.hba_port_list))[0][1]
+        assert_that(port.sp, equal_to(VNXSPEnum.SP_A))
+        assert_that(port.port_id, equal_to(3))
+        assert_that(port.host_initiator_list, has_item(uid))
+
+    @patch_cli
     def test_property_hosts(self):
         hosts = get_sg('~management').hosts
         assert_that(len(hosts), equal_to(2))

--- a/test/vnx/testdata/block_output/storagegroup_-messner_-list_-host_-iscsiAttributes_-gname_a.b.c.txt
+++ b/test/vnx/testdata/block_output/storagegroup_-messner_-list_-host_-iscsiAttributes_-gname_a.b.c.txt
@@ -1,0 +1,41 @@
+Storage Group Name:    wcmsc2-l-rh-cmp-2.hqplan.lab
+Storage Group UID:     BB:CD:9D:89:12:D9:E6:11:8D:24:82:E6:BF:48:3A:C7
+HBA/SP Pairs:
+
+  HBA UID                                          SP Name     SPPort
+  -------                                          -------     ------·
+  iqn.1994-05.com.abcdef:ghijk2-l-mn-opq-2.rstuvw.xyz:c3bf2f4ccaSP A1
+Host name:             wcmsc2-l-rh-cmp-2.hqplan.lab
+SPPort:                A-1v0
+Initiator IP:          N/A
+TPGT:                  6
+ISID:                  N/A
+
+  iqn.1994-05.com.abcdef:ghijk2-l-mn-opq-2.rstuvw.xyz:c3bf2f4ccbSP B 1
+Host name:             wcmsc2-l-rh-cmp-2.hqplan.lab
+SPPort:                B-1v0
+Initiator IP:          N/A
+TPGT:                  10
+ISID:                  N/A
+
+  iqn.1994-05.com.abcdef:ghijk2-l-mn-opq-2.rstuvw.xyz:c3bf2f4ccc SP A3
+Host name:             wcmsc2-l-rh-cmp-2.hqplan.lab
+SPPort:                A-3v0
+Initiator IP:          N/A
+TPGT:                  8
+ISID:                  N/A
+
+  iqn.1994-05.com.abcdef:ghijk2-l-mn-opq-2.rstuvw.xyz:c3bf2f4ccdSP B3
+Host name:             wcmsc2-l-rh-cmp-2.hqplan.lab
+SPPort:                B-3v0
+Initiator IP:          N/A
+TPGT:                  12
+ISID:                  N/A
+
+
+HLU/ALU Pairs:
+
+  HLU Number     ALU Number
+  ----------     ----------
+    196             24
+Shareable:             YES


### PR DESCRIPTION
When the HBA uid is too long, the table format of storage group output
is messed up.  There is no space between each column.

Luckly, the format for storage processor is fixed.  We could use it as the
token.  Modify the regular expression to parse the HBA and verify the
parsing of storage group with the messed output.

Bump the version to 0.4.4.