### PR TITLE
[GH-87]Add VNXLunSyncCompletedError for migration

### DIFF
--- a/storops/exception.py
+++ b/storops/exception.py
@@ -712,6 +712,11 @@ class VNXLunNotMigratingError(VNXMigrationError):
 
 
 @cli_exception
+class VNXLunSyncCompletedError(VNXMigrationError):
+    error_code = 0x714a8021
+
+
+@cli_exception
 class VNXTargetNotReadyError(VNXMigrationError):
     error_message = 'The destination LUN is not available for migration'
 

--- a/storops/vnx/resource/migration.py
+++ b/storops/vnx/resource/migration.py
@@ -60,6 +60,10 @@ class VNXMigrationSession(VNXCliResource):
     @property
     @instance_cache
     def source_lun(self):
+        if self._source is not None:
+            return storops.vnx.resource.lun.VNXLun(
+                lun_id=self._source,
+                cli=self._cli)
         return storops.vnx.resource.lun.VNXLun.get(
             cli=self._cli, lun_id=self.source_lu_id, name=self.source_lu_name)
 

--- a/test/vnx/resource/test_migration.py
+++ b/test/vnx/resource/test_migration.py
@@ -19,7 +19,7 @@ from unittest import TestCase
 
 from hamcrest import assert_that, equal_to, instance_of, raises
 
-from storops.exception import VNXLunNotMigratingError
+from storops.exception import VNXLunNotMigratingError, VNXLunSyncCompletedError
 from storops.vnx.resource.lun import VNXLun
 from test.vnx.cli_mock import t_cli, patch_cli
 from storops.vnx.enums import VNXMigrationRate
@@ -88,3 +88,12 @@ class VNXMigrationSessionTest(TestCase):
 
         assert_that(f, raises(VNXLunNotMigratingError,
                               'not currently migrating'))
+
+    @patch_cli
+    def test_cancel_migrate_sync_completed(self):
+        def f():
+            ms = VNXMigrationSession(1, t_cli())
+            ms.cancel()
+
+        assert_that(f, raises(VNXLunSyncCompletedError,
+                              'because data sychronization is completed'))

--- a/test/vnx/testdata/block_output/migrate_-cancel_-source_1_-o.txt
+++ b/test/vnx/testdata/block_output/migrate_-cancel_-source_1_-o.txt
@@ -1,0 +1,2 @@
+Error: migrate -cancel command failed.
+Migration cannot be cancelled because data sychronization is completed (0x714a8021)


### PR DESCRIPTION
When cancelling migration, a error message may come out:
Migration cannot be cancelled because data sychronization is completed
(0x714a8021)

This is to add a VNXLunSyncCompletedError to differentiate it from
general error.