### PR TITLE
[GH-90] Unity:Check version for attaching snap

### DIFF
--- a/storops/unity/resource/host.py
+++ b/storops/unity/resource/host.py
@@ -183,6 +183,9 @@ class UnityHost(UnityResource):
             lun_or_snap.attach_to(self)
             self.update()
             hlu = self.get_hlu(lun_or_snap)
+        except ex.SystemAPINotSupported:
+            # Attaching snap to host not support before 4.1.
+            raise
         except ex.UnityAttachExceedLimitError:
             # The number of luns exceeds system limit
             raise

--- a/storops/unity/resource/snap.py
+++ b/storops/unity/resource/snap.py
@@ -18,6 +18,7 @@ from __future__ import unicode_literals
 import logging
 
 from storops.lib.common import instance_cache
+from storops.lib.version import version
 from storops.unity import enums
 from storops.unity.enums import FilesystemSnapAccessTypeEnum, SnapStateEnum, \
     SnapAccessLevelEnum
@@ -104,6 +105,7 @@ class UnitySnap(UnityResource):
         return (super(UnitySnap, self).existed and
                 self.state != SnapStateEnum.DESTROYING)
 
+    @version('>=4.1')
     def attach_to(self, host, access_mask=SnapAccessLevelEnum.READ_WRITE):
         host_access = [{'host': host, 'allowedAccess': access_mask}]
         # If this lun has been attached to other host, don't overwrite it.


### PR DESCRIPTION
Attaching snap to host only supports from Unity OE version 4.1.

Although before the version 4.1, attaching snap to host would succeed,
the IO to the snap will fail.
We need to add version check to only allow attaching snap to host in
version 4.1 or later.