### PR TITLE
GH-99 Set property `parent_storage_processor`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ StorOps: The Python Library for VNX & Unity
 .. image:: https://landscape.io/github/emc-openstack/storops/master/landscape.svg?style=flat
     :target: https://landscape.io/github/emc-openstack/storops/
 
-VERSION: 0.4.7
+VERSION: 0.4.8
 
 A minimalist Python library to manage VNX/Unity systems.
 This document lies in the source code and go with the release.

--- a/storops/unity/parser_configs.yaml
+++ b/storops/unity/parser_configs.yaml
@@ -1097,8 +1097,6 @@ UnityEthernetPort:
       converter: EPSpeedValuesEnum
     - label: parentIOModule
       converter: UnityIoModule
-    - label: parentStorageProcessor
-      converter: UnityStorageProcessor
     - label: supportedSpeeds
       converter: EPSpeedValuesEnumList
     - label: requestedMtu

--- a/storops/unity/resource/port.py
+++ b/storops/unity/resource/port.py
@@ -223,6 +223,12 @@ class UnityEthernetPort(UnityResource):
             return _id.replace('spa', 'spb')
         return _id.replace('spb', 'spa')
 
+    @property
+    def parent_storage_processor(self):
+        # For ports on IO modules, there is no `parent_storage_processor`.
+        # Set it manually.
+        return self.storage_processor
+
 
 class UnityEthernetPortList(UnityResourceList):
     def __init__(self, cli=None, port_ids=None, **filters):

--- a/storops_test/unity/resource/test_port.py
+++ b/storops_test/unity/resource/test_port.py
@@ -110,6 +110,27 @@ class UnityEthernetPortTest(TestCase):
         assert_that(port.bond, equal_to(False))
 
     @patch_rest
+    def test_get_properties_io_module_port(self):
+        port = UnityEthernetPort('spa_iom_0_eth0', cli=t_rest())
+        assert_that(port.name, equal_to('SP A I/O Module 0 Ethernet Port 0'))
+        assert_that(port.mac_address, equal_to("00:60:16:57:EC:58"))
+        assert_that(port.parent_storage_processor, equal_to(
+            UnityStorageProcessor('spa', cli=t_rest())))
+        assert_that(port.mtu, equal_to(1500))
+        assert_that(port.requested_mtu, equal_to(0))
+        assert_that(port.connector_type, equal_to(ConnectorTypeEnum.LC))
+        assert_that(port.supported_speeds, only_contains(
+            EPSpeedValuesEnum.AUTO,
+            EPSpeedValuesEnum._100MbPS,
+            EPSpeedValuesEnum._1GbPS,
+            EPSpeedValuesEnum._10GbPS))
+        assert_that(port.supported_mtus, only_contains(1500, 9000))
+        assert_that(port.speed, equal_to(EPSpeedValuesEnum._10GbPS))
+        assert_that(port.needs_replacement, equal_to(False))
+        assert_that(port.is_link_up, equal_to(True))
+        assert_that(port.bond, equal_to(False))
+
+    @patch_rest
     def test_modify_mtu(self):
         port = UnityEthernetPort(cli=t_rest(), _id='spa_eth3')
         port.modify(mtu=9000)

--- a/storops_test/unity/rest_data/ethernetPort/index.json
+++ b/storops_test/unity/rest_data/ethernetPort/index.json
@@ -51,6 +51,10 @@
     {
       "url": "/api/types/ethernetPort/instances?compact=True&fields=bond,cascadeNames,connectorType,health,id,instanceId,isLinkUp,isRDMACapable,isRSSCapable,linuxDeviceName,macAddress,mtu,name,needsReplacement,operationalStatus,parent,parentIOModule,parentStorageProcessor,portNumber,requestedMtu,requestedSpeed,sfpSupportedProtocols,sfpSupportedSpeeds,shortName,speed,storageProcessor,supportedMtus,supportedSpeeds",
       "response": "all.json"
+    },
+    {
+      "url": "/api/instances/ethernetPort/spa_iom_0_eth0?compact=True&fields=bond,cascadeNames,connectorType,health,id,instanceId,isLinkUp,isRDMACapable,isRSSCapable,linuxDeviceName,macAddress,mtu,name,needsReplacement,operationalStatus,parent,parentIOModule,parentStorageProcessor,portNumber,requestedMtu,requestedSpeed,sfpSupportedProtocols,sfpSupportedSpeeds,shortName,speed,storageProcessor,supportedMtus,supportedSpeeds",
+      "response": "spa_iom_0_eth0.json"
     }
   ]
 }

--- a/storops_test/unity/rest_data/ethernetPort/spa_iom_0_eth0.json
+++ b/storops_test/unity/rest_data/ethernetPort/spa_iom_0_eth0.json
@@ -1,0 +1,50 @@
+{
+    "content": {
+        "id": "spa_iom_0_eth0",
+        "speed": 10000,
+        "connectorType": 2,
+        "requestedSpeed": 0,
+        "supportedSpeeds": [
+            0
+        ],
+        "sfpSupportedSpeeds": [
+            10000
+        ],
+        "sfpSupportedProtocols": [
+            2
+        ],
+        "health": {
+            "value": 5,
+            "descriptionIds": [
+                "ALRT_PORT_LINK_UP"
+            ],
+            "descriptions": [
+                "The port is operating normally."
+            ]
+        },
+        "needsReplacement": false,
+        "name": "SP A I/O Module 0 Ethernet Port 0",
+        "portNumber": 0,
+        "mtu": 1500,
+        "bond": false,
+        "isLinkUp": true,
+        "macAddress": "00:60:16:57:EC:58",
+        "isRSSCapable": false,
+        "isRDMACapable": false,
+        "requestedMtu": 0,
+        "supportedMtus": [
+            1500,
+            9000
+        ],
+        "parent": {
+            "id": "spa_iom_0",
+            "resource": "ioModule"
+        },
+        "storageProcessor": {
+            "id": "spa"
+        },
+        "parentIOModule": {
+            "id": "spa_iom_0"
+        }
+    }
+}


### PR DESCRIPTION
For ports on IO modules, there is no property
`parent_storage_processor`. Set it manually with the value of property
`storage_processor`