### PR TITLE
[GH-96] Update list members error.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include *.md
 include *.cfg
 include *.rst
+include *.txt
 recursive-include . *.txt
 recursive-include storops_test *.json
 recursive-include storops_test *.xml

--- a/storops/lib/resource.py
+++ b/storops/lib/resource.py
@@ -61,7 +61,12 @@ class Resource(JsonPrinter):
             data = self._get_raw_resource()
 
         self._parsed_resource = self._parse_raw(data)
+        self.update_name_if_exists()
         return self
+
+    def update_name_if_exists(self):
+        if hasattr(self, '_name') and self._name is None:
+            setattr(self, '_name', self._get_value_by_key("name"))
 
     def get_index(self):
         parser = self._get_parser()

--- a/storops_test/vnx/resource/test_cg.py
+++ b/storops_test/vnx/resource/test_cg.py
@@ -52,6 +52,14 @@ class VNXConsistencyGroupTest(TestCase):
         assert_that(cg_list.name, only_contains('another cg', 'test cg name'))
 
     @patch_cli
+    def test_update_consistency_group_list_member(self):
+        cg_list = VNXConsistencyGroup.get(t_cli())
+        cg = cg_list[1]
+        name = cg.name
+        cg.update()
+        assert_that(cg.name, equal_to(name))
+
+    @patch_cli
     def test_properties(self):
         cg = VNXConsistencyGroup(name="test_cg", cli=t_cli())
         assert_that(cg.name, equal_to('test_cg'))

--- a/storops_test/vnx/testdata/block_output/snap_-group_-list_-id_another cg_-detail.txt
+++ b/storops_test/vnx/testdata/block_output/snap_-group_-list_-id_another cg_-detail.txt
@@ -1,0 +1,5 @@
+Name:  another cg
+Description:
+Allow auto delete:  Yes
+Member LUN ID(s):  23, 24
+State:  Offline

--- a/storops_test/vnx/testdata/block_output/snap_-group_-list_-id_test cg name_-detail.txt
+++ b/storops_test/vnx/testdata/block_output/snap_-group_-list_-id_test cg name_-detail.txt
@@ -1,0 +1,5 @@
+Name:  test cg name
+Description: a cg 4 test
+Allow auto delete:  No
+Member LUN ID(s):  1, 3
+State:  Ready


### PR DESCRIPTION
The resource list class doesn't update the internal property `_name` or
`_id` of the resource instance.  When a resource instance within the
resource list tries to update itself, it couldn't find the unique key for
itself.

Fix part of the issue by assigning `name` to `_name` during updates.