### PR TITLE
Add supplement for the filesystem

### DIFF
--- a/storops/lib/common.py
+++ b/storops/lib/common.py
@@ -15,6 +15,7 @@
 #    under the License.
 from __future__ import unicode_literals
 
+import bitmath
 import errno
 import functools
 import inspect
@@ -541,3 +542,18 @@ def all_not_none(*items):
 
 def all_not_nan(*items):
     return all(map(lambda item: not math.isnan(item), items))
+
+
+def supplement_filesystem(old_size, user_cap=False):
+    """Return new size accounting for the metadata."""
+    new_size = old_size
+    if user_cap:
+        if old_size <= _GiB_to_Byte(1.5):
+            new_size = _GiB_to_Byte(3)
+        else:
+            new_size += _GiB_to_Byte(1.5)
+    return int(new_size)
+
+
+def _GiB_to_Byte(size_gb):
+    return bitmath.GiB(size_gb).to_Byte().value

--- a/storops/unity/resource/job.py
+++ b/storops/unity/resource/job.py
@@ -18,7 +18,7 @@ from __future__ import unicode_literals
 import retryz
 from storops import exception as ex
 from storops.exception import get_rest_exception
-from storops.lib.common import instance_cache
+from storops.lib.common import instance_cache, supplement_filesystem
 from storops.unity.resource import UnityResource, UnityResourceList, \
     UnityAttributeResource
 from storops.unity.enums import FSSupportedProtocolEnum
@@ -33,10 +33,11 @@ class UnityJob(UnityResource):
     @classmethod
     def create_nfs_share(cls, cli, pool, nas_server, name, size,
                          is_thin=None,
-                         tiering_policy=None, async=True):
+                         tiering_policy=None, async=True,
+                         user_cap=False):
         pool_clz = storops.unity.resource.pool.UnityPool
         nas_server_clz = storops.unity.resource.nas_server.UnityNasServer
-
+        size = supplement_filesystem(size, user_cap)
         pool = pool_clz.get(cli, pool)
         nas_server = nas_server_clz.get(cli, nas_server)
         proto = FSSupportedProtocolEnum.NFS

--- a/storops/unity/resource/pool.py
+++ b/storops/unity/resource/pool.py
@@ -31,7 +31,8 @@ LOG = logging.getLogger(__name__)
 
 class UnityPool(UnityResource):
     def create_filesystem(self, nas_server, name, size,
-                          proto=None, is_thin=None, tiering_policy=None):
+                          proto=None, is_thin=None, tiering_policy=None,
+                          user_cap=False):
         clz = storops.unity.resource.filesystem.UnityFileSystem
         return clz.create(self._cli, self,
                           nas_server=nas_server,
@@ -39,7 +40,8 @@ class UnityPool(UnityResource):
                           size=size,
                           proto=proto,
                           is_thin=is_thin,
-                          tiering_policy=tiering_policy)
+                          tiering_policy=tiering_policy,
+                          user_cap=user_cap)
 
     def create_lun(self, lun_name=None, size_gb=1, sp=None, host_access=None,
                    is_thin=None, description=None, tiering_policy=None,
@@ -54,11 +56,12 @@ class UnityPool(UnityResource):
                                io_limit_policy=io_limit_policy)
 
     def create_nfs_share(self, nas_server, name, size, is_thin=None,
-                         tiering_policy=None):
+                         tiering_policy=None, user_cap=False):
         clz = storops.unity.resource.job.UnityJob
         return clz.create_nfs_share(
             self._cli, self, nas_server, name, size,
-            is_thin, tiering_policy, False)
+            is_thin, tiering_policy, False,
+            user_cap=user_cap)
 
 
 class UnityPoolList(UnityResourceList):

--- a/storops_test/lib/test_common.py
+++ b/storops_test/lib/test_common.py
@@ -15,6 +15,7 @@
 #    under the License.
 from __future__ import unicode_literals
 
+import bitmath
 import logging
 from multiprocessing.pool import ThreadPool
 from time import sleep
@@ -26,7 +27,7 @@ from hamcrest import assert_that, equal_to, close_to, only_contains, raises, \
 from storops.exception import EnumValueNotFoundError
 from storops.lib.common import Dict, Enum, WeightedAverage, synchronized, \
     text_var, int_var, enum_var, yes_no_var, list_var, JsonPrinter, \
-    get_lock_file, EnumList, round_3, RepeatedTimer
+    get_lock_file, EnumList, round_3, RepeatedTimer, supplement_filesystem
 from storops.vnx.enums import VNXRaidType
 
 log = logging.getLogger(__name__)
@@ -334,3 +335,25 @@ class RepeatedTimerTest(TestCase):
         timer.start()
         assert_that(timer.is_daemon(), equal_to(True))
         assert_that(results[0], equal_to(0))
+
+
+class SupplementFilesystemTest(TestCase):
+    def test_size_larger_2(self):
+        size_byte = bitmath.GiB(2.5).to_Byte().value
+        new_size = supplement_filesystem(size_byte, True)
+        assert_that(new_size, equal_to(bitmath.GiB(4).to_Byte().value))
+        assert_that(str(new_size).isdigit(), equal_to(True))
+
+    def test_size_equal_1(self):
+        size_byte = bitmath.GiB(1).to_Byte().value
+        new_size = supplement_filesystem(size_byte, True)
+        assert_that(new_size, equal_to(bitmath.GiB(3).to_Byte().value))
+
+    def test_user_cap_no(self):
+        size_byte = bitmath.GiB(1).to_Byte().value
+        new_size = supplement_filesystem(size_byte, False)
+        assert_that(new_size, equal_to(bitmath.GiB(1).to_Byte().value))
+
+        size_byte = bitmath.GiB(3).to_Byte().value
+        new_size = supplement_filesystem(size_byte, False)
+        assert_that(new_size, equal_to(bitmath.GiB(3).to_Byte().value))


### PR DESCRIPTION
This patch adds extra capacity for filesystem metadata when user
specifies "user_cap=True" when creating/extending filesystem.