### PR TITLE
[GH-108] Not return bond ether port in get_file_port

### DIFF
--- a/storops/unity/resource/system.py
+++ b/storops/unity/resource/system.py
@@ -154,7 +154,7 @@ class UnitySystem(UnitySingletonResource):
 
         File ports includes ethernet ports and link aggregation ports.
         """
-        eths = self.get_ethernet_port()
+        eths = self.get_ethernet_port(bond=False)
         las = self.get_link_aggregation()
         return eths + las
 

--- a/storops_test/unity/resource/test_system.py
+++ b/storops_test/unity/resource/test_system.py
@@ -551,7 +551,7 @@ class UnitySystemTest(TestCase):
     def test_get_file_port(self):
         unity = UnitySystem(cli=t_rest("4.1.0"))
         ports = unity.get_file_port()
-        assert_that(len(ports), equal_to(10))
+        assert_that(len(ports), equal_to(6))
 
     @patch_rest
     def test_get_file_port_la_unsupported(self):

--- a/storops_test/unity/rest_data/ethernetPort/index.json
+++ b/storops_test/unity/rest_data/ethernetPort/index.json
@@ -55,6 +55,10 @@
     {
       "url": "/api/instances/ethernetPort/spa_iom_0_eth0?compact=True&fields=bond,cascadeNames,connectorType,health,id,instanceId,isLinkUp,isRDMACapable,isRSSCapable,linuxDeviceName,macAddress,mtu,name,needsReplacement,operationalStatus,parent,parentIOModule,parentStorageProcessor,portNumber,requestedMtu,requestedSpeed,sfpSupportedProtocols,sfpSupportedSpeeds,shortName,speed,storageProcessor,supportedMtus,supportedSpeeds",
       "response": "spa_iom_0_eth0.json"
+    },
+    {
+      "url": "/api/types/ethernetPort/instances?compact=True&fields=bond,cascadeNames,connectorType,health,id,instanceId,isLinkUp,isRDMACapable,isRSSCapable,linuxDeviceName,macAddress,mtu,name,needsReplacement,operationalStatus,parent,parentIOModule,parentStorageProcessor,portNumber,requestedMtu,requestedSpeed,sfpSupportedProtocols,sfpSupportedSpeeds,shortName,speed,storageProcessor,supportedMtus,supportedSpeeds&filter=bond eq False",
+      "response": "unbond_ethernet_ports.json"
     }
   ]
 }

--- a/storops_test/unity/rest_data/ethernetPort/unbond_ethernet_ports.json
+++ b/storops_test/unity/rest_data/ethernetPort/unbond_ethernet_ports.json
@@ -1,0 +1,247 @@
+{
+    "@base": "https://10.244.223.61/api/types/ethernetPort/instances?fields=bond,cascadeNames,connectorType,health,id,instanceId,isLinkUp,isRDMACapable,isRSSCapable,linuxDeviceName,macAddress,mtu,name,needsReplacement,operationalStatus,parent,portNumber,requestedMtu,requestedSpeed,sfpSupportedProtocols,sfpSupportedSpeeds,shortName,speed,supportedMtus,supportedSpeeds,parentStorageProcessor.id,parentIOModule.id,storageProcessor.id&per_page=2000&compact=true",
+    "updated": "2016-12-20T02:13:54.948Z",
+    "links": [
+        {
+            "href": "&page=1",
+            "rel": "self"
+        }
+    ],
+    "entries": [
+        {
+            "content": {
+                "macAddress": "00:60:16:5C:07:0B",
+                "isRDMACapable": false,
+                "parentStorageProcessor": {
+                    "id": "spa"
+                },
+                "instanceId": "root/emc:EMC_UEM_EthernetPortLeaf%Tag=03:00:00:00",
+                "portNumber": 2,
+                "cascadeNames": [
+                    "Ethernet Port 2",
+                    "SP A"
+                ],
+                "requestedMtu": 1500,
+                "mtu": 1500,
+                "speed": 1000,
+                "id": "spa_eth2",
+                "supportedSpeeds": [
+                    1000,
+                    10000,
+                    100,
+                    0
+                ],
+                "supportedMtus": [
+                    1500,
+                    9000
+                ],
+                "storageProcessor": {
+                    "id": "spa"
+                },
+                "connectorType": 1,
+                "health": {
+                    "descriptionIds": [
+                        "ALRT_PORT_LINK_UP"
+                    ],
+                    "descriptions": [
+                        "The port is operating normally."
+                    ],
+                    "value": 5
+                },
+                "parent": {
+                    "resource": "storageProcessor",
+                    "id": "spa"
+                },
+                "needsReplacement": false,
+                "sfpSupportedSpeeds": [],
+                "sfpSupportedProtocols": [],
+                "operationalStatus": [
+                    2,
+                    32784
+                ],
+                "shortName": "Ethernet Port 2",
+                "requestedSpeed": 0,
+                "isRSSCapable": false,
+                "name": "SP A Ethernet Port 2",
+                "linuxDeviceName": "eth2",
+                "isLinkUp": true,
+                "bond": false
+            }
+        },
+        {
+            "content": {
+                "macAddress": "00:60:16:5C:07:0A",
+                "isRDMACapable": false,
+                "parentStorageProcessor": {
+                    "id": "spa"
+                },
+                "instanceId": "root/emc:EMC_UEM_EthernetPortLeaf%Tag=03:00:00:01",
+                "portNumber": 3,
+                "cascadeNames": [
+                    "Ethernet Port 3",
+                    "SP A"
+                ],
+                "requestedMtu": 0,
+                "mtu": 1500,
+                "connectorType": 1,
+                "id": "spa_eth3",
+                "supportedSpeeds": [
+                    1000,
+                    10000,
+                    100,
+                    0
+                ],
+                "supportedMtus": [
+                    1500,
+                    9000
+                ],
+                "storageProcessor": {
+                    "id": "spa"
+                },
+                "health": {
+                    "descriptionIds": [
+                        "ALRT_PORT_LINK_DOWN_NOT_IN_USE"
+                    ],
+                    "descriptions": [
+                        "The port link is down, but not in use. No action is required."
+                    ],
+                    "value": 5
+                },
+                "parent": {
+                    "resource": "storageProcessor",
+                    "id": "spa"
+                },
+                "needsReplacement": false,
+                "sfpSupportedSpeeds": [],
+                "sfpSupportedProtocols": [],
+                "operationalStatus": [
+                    2,
+                    32785
+                ],
+                "shortName": "Ethernet Port 3",
+                "requestedSpeed": 0,
+                "isRSSCapable": false,
+                "name": "SP A Ethernet Port 3",
+                "linuxDeviceName": "eth3",
+                "isLinkUp": false,
+                "bond": false
+            }
+        },
+        {
+            "content": {
+                "macAddress": "08:00:1B:FF:16:F9",
+                "isRDMACapable": false,
+                "parentStorageProcessor": {
+                    "id": "spa"
+                },
+                "instanceId": "root/emc:EMC_UEM_ManagementPortLeaf%Tag=00:00:00:00",
+                "portNumber": 0,
+                "cascadeNames": [
+                    "Management Port",
+                    "SP A"
+                ],
+                "requestedMtu": 0,
+                "mtu": 1500,
+                "speed": 1000,
+                "id": "spa_mgmt",
+                "supportedSpeeds": [
+                    1000,
+                    10,
+                    100,
+                    0
+                ],
+                "supportedMtus": [
+                    1500
+                ],
+                "storageProcessor": {
+                    "id": "spa"
+                },
+                "connectorType": 1,
+                "health": {
+                    "descriptionIds": [
+                        "ALRT_PORT_LINK_UP"
+                    ],
+                    "descriptions": [
+                        "The port is operating normally."
+                    ],
+                    "value": 5
+                },
+                "parent": {
+                    "resource": "storageProcessor",
+                    "id": "spa"
+                },
+                "needsReplacement": false,
+                "sfpSupportedSpeeds": [],
+                "sfpSupportedProtocols": [],
+                "operationalStatus": [
+                    32784
+                ],
+                "shortName": "Management Port",
+                "requestedSpeed": 0,
+                "isRSSCapable": false,
+                "name": "SP A Management Port",
+                "linuxDeviceName": "mgmt_vdev",
+                "isLinkUp": true,
+                "bond": false
+            }
+        },
+        {
+            "content": {
+                "macAddress": "76:CA:E8:15:06:34",
+                "isRDMACapable": false,
+                "parentStorageProcessor": {
+                    "id": "spa"
+                },
+                "instanceId": "root/emc:EMC_UEM_ManagementPortLeaf%Tag=00:00:00:FF",
+                "portNumber": 0,
+                "cascadeNames": [
+                    "Sync Replication Management Port",
+                    "SP A"
+                ],
+                "requestedMtu": 0,
+                "mtu": 1500,
+                "speed": 1000,
+                "id": "spa_srm",
+                "supportedSpeeds": [
+                    1000,
+                    10,
+                    100,
+                    0
+                ],
+                "supportedMtus": [
+                    1500
+                ],
+                "storageProcessor": {
+                    "id": "spa"
+                },
+                "connectorType": 1,
+                "health": {
+                    "descriptionIds": [
+                        "ALRT_PORT_LINK_UP"
+                    ],
+                    "descriptions": [
+                        "The port is operating normally."
+                    ],
+                    "value": 5
+                },
+                "parent": {
+                    "resource": "storageProcessor",
+                    "id": "spa"
+                },
+                "needsReplacement": false,
+                "sfpSupportedSpeeds": [],
+                "sfpSupportedProtocols": [],
+                "operationalStatus": [
+                    32784
+                ],
+                "shortName": "Sync Replication Management Port",
+                "requestedSpeed": 0,
+                "isRSSCapable": false,
+                "name": "SP A Sync Replication Management Port",
+                "linuxDeviceName": "srm",
+                "isLinkUp": true,
+                "bond": false
+            }
+        }
+    ]
+}


### PR DESCRIPTION
The bond port is port that has been added to link aggregation. The
get_file_port should not return them because the bond port can not
be used to create interfaces.