### PR TITLE
[GH-115]Fix incompatible issue with VSA

### DIFF
--- a/storops/exception.py
+++ b/storops/exception.py
@@ -359,6 +359,10 @@ class UnityResourceNotFoundError(UnityException):
     error_code = 131149829
 
 
+class UnityResourceNotSupportedError(UnityResourceNotFoundError):
+    pass
+
+
 @rest_exception
 class UnityNasServerNameUsedError(UnityException):
     error_code = 108011556

--- a/storops/unity/client.py
+++ b/storops/unity/client.py
@@ -18,7 +18,9 @@ from __future__ import unicode_literals
 import logging
 
 import six
+from functools import wraps
 
+from storops.exception import UnityResourceNotSupportedError
 import storops.unity.resource.type_resource
 from storops.connection.connector import UnityRESTConnector
 from storops.lib.common import instance_cache, EnumList
@@ -33,6 +35,17 @@ __author__ = 'Cedric Zhuang'
 log = logging.getLogger(__name__)
 
 
+def wrap_not_supported(func):
+    @wraps(func)
+    def _wrap(*args, **kwargs):
+        try:
+            ret = func(*args, **kwargs)
+        except UnityResourceNotSupportedError:
+            ret = RestResponse(inputs="")
+        return ret
+    return _wrap
+
+
 class UnityClient(PerfManager):
     def __init__(self, ip, username, password, port=443, verify=False):
         super(UnityClient, self).__init__()
@@ -42,6 +55,7 @@ class UnityClient(PerfManager):
                                         verify=verify)
         self._system_version = None
 
+    @wrap_not_supported
     def get_all(self, type_name, base_fields=None, the_filter=None,
                 nested_fields=None):
         """Get the resource by resource id.
@@ -147,6 +161,7 @@ class UnityClient(PerfManager):
     def get_doc(self, clz):
         return UnityDoc.get_doc(self, clz)
 
+    @wrap_not_supported
     def get(self, type_name, obj_id, base_fields=None, nested_fields=None):
         """Get the resource by resource id.
 

--- a/storops_test/unity/resource/test_port.py
+++ b/storops_test/unity/resource/test_port.py
@@ -31,7 +31,7 @@ from storops.unity.resource.port import UnityEthernetPort, \
     UnityEthernetPortList, UnityIpPort, UnityIpPortList, UnityIscsiPortal, \
     UnityIscsiPortalList, UnityIscsiNode, UnityFcPort, UnityFcPortList, \
     UnityIoLimitRule, UnityIoLimitPolicy, UnityIoLimitPolicyList, \
-    UnityLinkAggregation
+    UnityLinkAggregation, UnityLinkAggregationList
 from storops.unity.resource.sp import UnityStorageProcessor
 from storops_test.unity.rest_mock import t_rest, patch_rest
 
@@ -392,3 +392,8 @@ class UnityLinkAggregationTest(TestCase):
         def f():
             UnityLinkAggregation.get(t_rest("4.0.0"))
         assert_that(f, raises(SystemAPINotSupported))
+
+    @patch_rest(output='link_aggregation_not_supported.json')
+    def test_link_aggregation_not_supported(self):
+        ports = UnityLinkAggregationList(cli=t_rest("4.1.2"))
+        assert_that(len(ports), equal_to(0))

--- a/storops_test/unity/resource/test_system.py
+++ b/storops_test/unity/resource/test_system.py
@@ -417,6 +417,12 @@ class UnitySystemTest(TestCase):
         assert_that(fi_list, instance_of(UnityFcPortList))
         assert_that(len(fi_list), equal_to(12))
 
+    @patch_rest(output='fc_port_not_supported.json')
+    def test_get_fc_port_not_supported(self):
+        unity = t_unity(version='4.1.2')
+        fc = unity.get_fc_port()
+        assert_that(len(fc), equal_to(0))
+
     @patch_rest
     def test_get_io_limit_policy_by_name(self):
         unity = t_unity()
@@ -546,6 +552,12 @@ class UnitySystemTest(TestCase):
     def test_get_link_aggregation_by_id(self):
         cg = t_unity().get_link_aggregation(_id='spa_la_2')
         assert_that(cg.id, equal_to('spa_la_2'))
+
+    @patch_rest(output='link_aggregation_not_supported.json')
+    def test_get_link_aggregation_not_supported(self):
+        unity = t_unity(version='4.1.2')
+        la = unity.get_link_aggregation()
+        assert_that(len(la), equal_to(0))
 
     @patch_rest
     def test_get_file_port(self):

--- a/storops_test/unity/rest_data/fcPort/fc_port_not_supported.json
+++ b/storops_test/unity/rest_data/fcPort/fc_port_not_supported.json
@@ -1,0 +1,12 @@
+{
+  "error": {
+    "errorCode": 131149829,
+    "httpStatusCode": 404,
+    "messages": [
+      {
+        "en-US": "The requested resource does not exist. (Error Code:0x7d13005)"
+      }
+    ],
+    "created": "2017-03-27T02:50:28.963Z"
+  }
+}

--- a/storops_test/unity/rest_data/linkAggregation/link_aggregation_not_supported.json
+++ b/storops_test/unity/rest_data/linkAggregation/link_aggregation_not_supported.json
@@ -1,0 +1,12 @@
+{
+  "error": {
+    "errorCode": 131149829,
+    "httpStatusCode": 404,
+    "messages": [
+      {
+        "en-US": "The requested resource does not exist. (Error Code:0x7d13005)"
+      }
+    ],
+    "created": "2017-03-27T02:50:28.963Z"
+  }
+}

--- a/storops_test/unity/rest_mock.py
+++ b/storops_test/unity/rest_mock.py
@@ -46,11 +46,12 @@ def t_rest(version=None):
 
 
 @cache
-def t_unity():
+def t_unity(version=None):
     clz = storops.unity.resource.system.UnitySystem
     unity = clz('10.244.223.61', 'admin', 'Password123!', verify=False)
     unity.add_metric_record(unity.get_metric_query_result(17))
     unity.add_metric_record(unity.get_metric_query_result(34))
+    unity._cli.set_system_version(version)
     return unity
 
 


### PR DESCRIPTION
When query UnityLinkAggregation or UnityFcPort on VSA, a exception will
be thrown. This fix will handle the 404 not found error and return an
empty list on any query for link aggregation or fc port.