### PR TITLE
[GH-114]Add a exception for initiator creation

### DIFF
--- a/storops/exception.py
+++ b/storops/exception.py
@@ -293,6 +293,11 @@ class UnityHostInitiatorNotFoundError(UnityException):
     pass
 
 
+@rest_exception
+class UnityHostInitiatorExistedError(UnityException):
+    error_code = 100663539
+
+
 class UnityHostInitiatorUnknownType(UnityException):
     pass
 

--- a/storops_test/unity/resource/test_host.py
+++ b/storops_test/unity/resource/test_host.py
@@ -26,7 +26,7 @@ from storops.exception import UnityHostIpInUseError, \
     UnityResourceNotFoundError, UnityHostInitiatorNotFoundError, \
     UnityHostInitiatorUnknownType, UnityAluAlreadyAttachedError, \
     UnityAttachAluExceedLimitError, UnitySnapAlreadyPromotedException, \
-    SystemAPINotSupported
+    SystemAPINotSupported, UnityHostInitiatorExistedError
 from storops.unity.enums import HostTypeEnum, HostManageEnum, \
     HostPortTypeEnum, HealthEnum, HostInitiatorTypeEnum, \
     HostInitiatorSourceTypeEnum, HostInitiatorIscsiTypeEnum
@@ -45,7 +45,7 @@ __author__ = 'Cedric Zhuang'
 
 
 @ddt.ddt
-class UnityHotTest(TestCase):
+class UnityHostTest(TestCase):
     @patch_rest
     def test_properties(self):
         host = UnityHost(_id='Host_1', cli=t_rest())
@@ -200,6 +200,15 @@ class UnityHotTest(TestCase):
         assert_that(initiator.existed, equal_to(True))
         assert_that(host.iscsi_host_initiators,
                     instance_of(UnityHostInitiatorList))
+
+    @patch_rest
+    def test_add_initiator_iscsi_already_existed(self):
+        host = UnityHost(cli=t_rest(), _id='Host_9')
+        iqn = "iqn.1993-08.org.debian:01:a4f95ed19999"
+
+        def _inner():
+            host.add_initiator(iqn)
+        assert_that(_inner, raises(UnityHostInitiatorExistedError))
 
     @patch_rest
     def test_add_not_exist_initiator_with_force(self):

--- a/storops_test/unity/rest_data/hostInitiator/index.json
+++ b/storops_test/unity/rest_data/hostInitiator/index.json
@@ -93,6 +93,17 @@
         "response": "create_iscsi_initiator.json"
     },
     {
+      "url": "/api/types/hostInitiator/instances?compact=True",
+        "body":  {
+          "host": {
+              "id": "Host_9"
+          },
+          "initiatorType": 2,
+          "initiatorWWNorIqn": "iqn.1993-08.org.debian:01:a4f95ed19999"
+        },
+        "response": "initiator_already_existed.json"
+    },
+    {
       "url": "/api/instances/hostInitiator/HostInitiator_1/action/modify?compact=True",
       "body": {
         "host": []

--- a/storops_test/unity/rest_data/hostInitiator/initiator_already_existed.json
+++ b/storops_test/unity/rest_data/hostInitiator/initiator_already_existed.json
@@ -1,0 +1,12 @@
+{
+    "error": {
+        "errorCode": 100663539,
+            "httpStatusCode": 422,
+            "messages": [
+            {
+                "en-US": "The specified host initiator already exists. (Error Code:0x60000f3)"
+            }
+            ],
+            "created": "2017-03-23T20:56:53.012Z"
+    }
+}


### PR DESCRIPTION
This patch will raise UnityHostInitiatorExistedError when meets
below error:

  The specified host initiator already exists. (Error Code:0x60000f3)