### PR TITLE
[GH-118]Fix initiator issue for RH distro

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ StorOps: The Python Library for VNX & Unity
 .. image:: https://landscape.io/github/emc-openstack/storops/master/landscape.svg?style=flat
     :target: https://landscape.io/github/emc-openstack/storops/
 
-VERSION: 0.4.10
+VERSION: 0.4.11
 
 A minimalist Python library to manage VNX/Unity systems.
 This document lies in the source code and go with the release.

--- a/storops/lib/common.py
+++ b/storops/lib/common.py
@@ -21,6 +21,7 @@ import functools
 import inspect
 import json
 import logging
+import re
 import sys
 import threading
 from functools import partial
@@ -557,3 +558,16 @@ def supplement_filesystem(old_size, user_cap=False):
 
 def _GiB_to_Byte(size_gb):
     return bitmath.GiB(size_gb).to_Byte().value
+
+
+def is_iscsi_uid(uid):
+    """Validate the iSCSI initiator format.
+
+    :param uid: format like iqn.yyyy-mm.naming-authority:unique
+    """
+    return uid.startswith('iqn')
+
+
+def is_fc_uid(uid):
+    """Validate the FC initiator format."""
+    return re.match("(\w{2}:){15}\w{2}", uid, re.I) is not None

--- a/storops/unity/resource/host.py
+++ b/storops/unity/resource/host.py
@@ -16,13 +16,13 @@
 from __future__ import unicode_literals
 
 import logging
-import re
 from itertools import chain
 
 import six
 
 from storops import exception as ex
 from storops.lib import converter
+from storops.lib import common
 from storops.unity.enums import HostTypeEnum, HostInitiatorTypeEnum
 from storops.unity.resource import UnityResource, UnityResourceList, \
     UnityAttributeResource
@@ -251,10 +251,9 @@ class UnityHost(UnityResource):
 
         if not initiators:
             # Set the ISCSI or FC type
-            if re.match("(\w{2}:){15}\w{2}", uid, re.I):
+            if common.is_fc_uid(uid):
                 uid_type = HostInitiatorTypeEnum.FC
-            elif re.match("iqn.\d{4}-\d{2}.\w+.\w+:\d+:[A-F0-9]+", uid, re.I):
-                # iqn.yyyy-mm.<reversed domain name>[:identifier] )
+            elif common.is_iscsi_uid(uid):
                 uid_type = HostInitiatorTypeEnum.ISCSI
             else:
                 uid_type = HostInitiatorTypeEnum.UNKNOWN

--- a/storops_test/lib/test_common.py
+++ b/storops_test/lib/test_common.py
@@ -25,6 +25,7 @@ from hamcrest import assert_that, equal_to, close_to, only_contains, raises, \
     contains_string, has_items
 
 from storops.exception import EnumValueNotFoundError
+from storops.lib import common
 from storops.lib.common import Dict, Enum, WeightedAverage, synchronized, \
     text_var, int_var, enum_var, yes_no_var, list_var, JsonPrinter, \
     get_lock_file, EnumList, round_3, RepeatedTimer, supplement_filesystem
@@ -357,3 +358,27 @@ class SupplementFilesystemTest(TestCase):
         size_byte = bitmath.GiB(3).to_Byte().value
         new_size = supplement_filesystem(size_byte, False)
         assert_that(new_size, equal_to(bitmath.GiB(3).to_Byte().value))
+
+
+class InitiatorFormatTest(TestCase):
+    def test_iscsi_format_rh(self):
+        assert_that(common.is_iscsi_uid('iqn.1994-05.com.redhat:4dc0b7e1edc9'),
+                    equal_to(True))
+
+    def test_iscsi_format_debian(self):
+        assert_that(
+            common.is_iscsi_uid('iqn.1993-08.org.debian:01:816ce05feaa6'),
+            equal_to(True))
+
+    def test_iscsi_format_invalid(self):
+        assert_that(common.is_iscsi_uid('invalid format'), equal_to(False))
+
+    def test_fc_format(self):
+        assert_that(
+            common.is_fc_uid(
+                '20:00:00:90:DA:73:5C:D1:10:00:00:90:FB:54:4C:D1'),
+            equal_to(True))
+
+    def test_fc_format_invalid(self):
+        assert_that(
+            common.is_fc_uid('20:00:00:90:DA:73:5C:D1'), equal_to(False))


### PR DESCRIPTION
storops treats format for RedHat initiator as invalid, this causes
issue when creating HostInitiator.

Now, any initiator name starting with "iqn" will be treated as valid.