### PR TITLE
[GH-123]Make paramiko as optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,11 +16,11 @@ StorOps: The Python Library for VNX & Unity
 .. image:: https://landscape.io/github/emc-openstack/storops/master/landscape.svg?style=flat
     :target: https://landscape.io/github/emc-openstack/storops/
 
-VERSION: 0.4.11
+VERSION: 0.4.12
 
 A minimalist Python library to manage VNX/Unity systems.
 This document lies in the source code and go with the release.
-Check different release branch/tag for matched documents. 
+Check different release branch/tag for matched documents.
 
 License
 -------
@@ -36,9 +36,16 @@ You could use "pip" to install "storops".
 
     $ pip install storops
 
-Make sure naviseccli is installed if you want to manage VNX.
+Make sure `naviseccli` is installed if you want to manage VNX.
 
-*PIP Install Failed?*
+Optional package requirement
+````````````````````````````
+
+#. `paramiko` package
+
+The `paramiko` is required if you need to manage the VNX file related
+resources. please follow `install paramiko <http://www.paramiko.org/installing.html>`_ install `paramiko`.
+
 
 Feature List
 ------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-paramiko>=1.13.0 # LGPLv2.1+, cinder, manila
 requests!=2.9.0,>=2.8.1 # Apache-2.0, cinder, manila
 PyYAML>=3.11 # MIT, cinder, manila
 six>=1.9.0 # MIT, cinder, manila

--- a/storops/connection/connector.py
+++ b/storops/connection/connector.py
@@ -16,17 +16,18 @@
 
 from __future__ import unicode_literals
 
+from storops.lib import common
 import logging
 import pipes
 
 import functools
-import paramiko
-from paramiko import ssh_exception
 import six
 from storops.connection import client
 from storops.connection.exceptions import SFtpExecutionError, \
     SSHExecutionError, HTTPClientError
 from retryz import retry
+
+paramiko = common.try_import('paramiko')
 
 LOG = logging.getLogger(__name__)
 
@@ -140,7 +141,7 @@ class SSHConnector(object):
         if password:
             try:
                 self.transport.connect(username=username, password=password)
-            except ssh_exception.SSHException as ex:
+            except paramiko.ssh_exception.SSHException as ex:
                 error_msg = ('Failed to setup SSH connection. '
                              'Reason:%s.' % six.text_type(ex))
                 LOG.error(error_msg)

--- a/storops/lib/common.py
+++ b/storops/lib/common.py
@@ -571,3 +571,11 @@ def is_iscsi_uid(uid):
 def is_fc_uid(uid):
     """Validate the FC initiator format."""
     return re.match("(\w{2}:){15}\w{2}", uid, re.I) is not None
+
+
+def try_import(import_str, default=None):
+    try:
+        __import__(import_str)
+        return sys.modules[import_str]
+    except ImportError:
+        return default

--- a/storops_test/lib/test_common.py
+++ b/storops_test/lib/test_common.py
@@ -22,13 +22,14 @@ from time import sleep
 from unittest import TestCase
 
 from hamcrest import assert_that, equal_to, close_to, only_contains, raises, \
-    contains_string, has_items
+    contains_string, has_items, not_none, none
 
 from storops.exception import EnumValueNotFoundError
 from storops.lib import common
 from storops.lib.common import Dict, Enum, WeightedAverage, synchronized, \
     text_var, int_var, enum_var, yes_no_var, list_var, JsonPrinter, \
-    get_lock_file, EnumList, round_3, RepeatedTimer, supplement_filesystem
+    get_lock_file, EnumList, round_3, RepeatedTimer, supplement_filesystem, \
+    try_import
 from storops.vnx.enums import VNXRaidType
 
 log = logging.getLogger(__name__)
@@ -300,6 +301,14 @@ class CommonTest(TestCase):
         name = get_lock_file('a.lock')
         assert_that(name, contains_string('.storops'))
         assert_that(name, contains_string('a.lock'))
+
+    def test_try_import_none(self):
+        mod = try_import('paramiko_none')
+        assert_that(mod, none())
+
+    def test_try_import_normal(self):
+        mod = try_import('os')
+        assert_that(mod, not_none())
 
 
 class RoundItTest(TestCase):


### PR DESCRIPTION
The paramiko is now optional since it's not widely used in storops.
If user wants to manage VNX file resources, he could install paramiko.

This makes the installation of storops much more easier for most use
cases.