### PR TITLE
[GH-128] Enhance rpm packaging

### DIFF
--- a/utility/rpm_publish/readme.md
+++ b/utility/rpm_publish/readme.md
@@ -1,20 +1,13 @@
 # How to publish storops rpm package
 
-- cd to `rpm_publish`.
-- Update `Version` and `Change log` in the `storops_rpm.spec`.
+- cd to root directory where the `requirements.txt` is.
+- Update `Version` and `Change log` in the `utility/rpm_publish/storops_rpm.spec`.
 - Run command: `rpmbuild -ba storops_rpm.spec -v`
 - Follow the log on the screen to find the rpm built.
-
-*NOTE* all pypi packages specified in `requirements.os.txt` will be downloaded
-from `https://pypi.python.org/pypi` and packaged to the rpm.
 
 
 # How to install storops rpm package
 
-Make sure the host has `pip`, `gcc`, `python header files`, `ssl header files`
-installed.
+Make sure the host has `pip` installed.
 If not, use below commands to install.
 - sudo yum install python-pip
-- sudo yum install gcc.x86_64
-- sudo yum install python-devel.x86_64
-- sudo yum install openssl-devel.x86_64

--- a/utility/rpm_publish/requirements.os.txt
+++ b/utility/rpm_publish/requirements.os.txt
@@ -1,8 +1,0 @@
-## Please download these files with "--no-deps" option, e.g.
-##   pip download --no-deps -r <path to>/requirements.os.txt
-python-dateutil>=2.4.2 # BSD
-retryz>=0.1.8 # Apache-2.0
-cachez>=0.1.0 # Apache-2.0
-bitmath>=1.3.0 # MIT
-persist-queue==0.2.1 # BSD
-storops # Apache-2.0

--- a/utility/rpm_publish/storops_rpm.spec
+++ b/utility/rpm_publish/storops_rpm.spec
@@ -16,11 +16,13 @@ RPM package of Storops for Openstack distribution.
 # create the folders
 mkdir -p $RPM_BUILD_ROOT/tmp/storops
 
-pip download -r %{getenv:PWD}/requirements.os.txt --no-deps -d $RPM_BUILD_ROOT/tmp/storops
+cp %{getenv:PWD}/requirements.txt $RPM_BUILD_ROOT/tmp/storops
+pip download -r $RPM_BUILD_ROOT/tmp/storops/requirements.txt -d $RPM_BUILD_ROOT/tmp/storops
+pip download -d $RPM_BUILD_ROOT/tmp/storops --no-deps storops
 
 %post
 echo Installing storops and dependencies.
-pip install /tmp/storops/*
+pip install --no-index --find-links file:///tmp/storops storops
 
 %clean
 rm -rf "$RPM_BUILD_ROOT/tmp"
@@ -28,6 +30,7 @@ rm -rf "$RPM_BUILD_ROOT/tmp"
 %files
 %defattr (-,root,root)
 /tmp/storops/*
+
 
 %changelog
 * Fri Mar 23 2017 Denny Zhao


### PR DESCRIPTION
- Use only one `requirements.txt`.
- Download the pypi packages based on the `requirements.txt`.
- Install the packages using `pip find-links`, which will find packages under a directory and will not upgrade the installed packages.