### PR TITLE
[GH-155]UT on python34 failed always

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,8 +25,12 @@ environment:
 install:
   # We need wheel installed to build wheels
   - echo Installed Pythons
+  - pip.exe list
   - dir C:\Python*
   - "%PYTHON%\\python.exe -m pip install tox"
+  # Try to workaround the issue:
+  # Expected version spec in enum34;python_version<"3.4" # BSD at ;python_version<"3.4" # BSD
+  - "%PYTHON%\\python.exe -m pip install --upgrade pip setuptools"
 
 build: off
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 requests!=2.9.0,>=2.8.1 # Apache-2.0, cinder, manila
 PyYAML>=3.10 # MIT, cinder, manila
 six>=1.9.0 # MIT, cinder, manila
-enum34;python_version=='2.7' or python_version=='2.6' or python_version=='3.3' # BSD
+enum34;python_version<'3.4' # BSD
 
 python-dateutil>=2.4.2 # BSD
 retryz>=0.1.8 # Apache-2.0


### PR DESCRIPTION
The `requirements.txt` caused the UT failure.
Below line:
```
enum34;python_version=='2.7' or python_version=='2.6' or
python_version=='3.3' # BSD
```
Need to change it to:
```
enum34;python_version<'3.4' # BSD
```