### PR TITLE
Fix issue when deleting base LUN of thin clone.

### DIFF
--- a/storops/unity/resource/lun.py
+++ b/storops/unity/resource/lun.py
@@ -19,7 +19,7 @@ import logging
 
 import storops.unity.resource.pool
 from storops.exception import UnityResourceNotFoundError
-from storops.lib.thinclone_helper import TCHelper
+from storops.lib.thinclone_helper import TCHelper, wrap_tc_deletion
 from storops.lib.version import version
 from storops.unity.enums import TieringPolicyEnum, NodeEnum, \
     HostLUNAccessEnum, ThinCloneActionEnum
@@ -180,6 +180,7 @@ class UnityLun(UnityResource):
         resp.raise_if_err()
         return resp
 
+    @wrap_tc_deletion
     def delete(self, async=False, force_snap_delete=False,
                force_vvol_delete=False):
         sr = self.storage_resource
@@ -192,8 +193,6 @@ class UnityLun(UnityResource):
                                 async=async)
         resp.raise_if_err()
 
-        if self.is_thin_clone:
-            TCHelper.notify(self, ThinCloneActionEnum.TC_DELETE)
         return resp
 
     def attach_to(self, host, access_mask=HostLUNAccessEnum.PRODUCTION):

--- a/storops_test/unity/rest_data/lun/index.json
+++ b/storops_test/unity/rest_data/lun/index.json
@@ -36,7 +36,7 @@
       "url": "/api/types/lun/instances?compact=True&fields=auSize,creationTime,currentNode,defaultNode,description,health,hostAccess,hostAccess.host.name,id,instanceId,ioLimitPolicy,isReplicationDestination,isSnapSchedulePaused,isThinEnabled,lunGroupObjectId,metadataSize,metadataSizeAllocated,modificationTime,name,objectId,operationalStatus,perTierSizeUsed,pool,pool.isFASTCacheEnabled,pool.raidType,sizeAllocated,sizeTotal,sizeUsed,smpBackendId,snapCount,snapSchedule,snapWwn,snapsSize,snapsSizeAllocated,storageResource,tieringPolicy,type,wwn",
       "response": "all.json"
     },
-      {
+    {
       "url": "/api/types/lun/instances?compact=True&fields=auSize,creationTime,currentNode,defaultNode,description,health,hostAccess,hostAccess.host.name,id,instanceId,ioLimitPolicy,isReplicationDestination,isSnapSchedulePaused,isThinEnabled,lunGroupObjectId,metadataSize,metadataSizeAllocated,modificationTime,name,objectId,operationalStatus,perTierSizeUsed,pool,pool.isFASTCacheEnabled,pool.raidType,sizeAllocated,sizeTotal,sizeUsed,smpBackendId,snapCount,snapSchedule,snapWwn,snapsSize,snapsSizeAllocated,storageResource,tieringPolicy,type,wwn&filter=name eq \"openstack_lun\"",
       "response": "sv_2.json"
     },
@@ -119,6 +119,10 @@
     {
       "url": "/api/instances/lun/sv_5607?compact=True&fields=auSize,creationTime,currentNode,defaultNode,description,health,hostAccess,hostAccess.host.name,id,instanceId,ioLimitPolicy,isReplicationDestination,isSnapSchedulePaused,isThinEnabled,lunGroupObjectId,metadataSize,metadataSizeAllocated,modificationTime,name,objectId,operationalStatus,perTierSizeUsed,pool,pool.isFASTCacheEnabled,pool.raidType,sizeAllocated,sizeTotal,sizeUsed,smpBackendId,snapCount,snapSchedule,snapWwn,snapsSize,snapsSizeAllocated,storageResource,tieringPolicy,type,wwn",
       "response": "sv_5607.json"
+    },
+    {
+      "url": "/api/instances/lun/sv_5608?compact=True&fields=auSize,creationTime,currentNode,defaultNode,description,health,hostAccess,hostAccess.host.name,id,instanceId,ioLimitPolicy,isReplicationDestination,isSnapSchedulePaused,isThinEnabled,lunGroupObjectId,metadataSize,metadataSizeAllocated,modificationTime,name,objectId,operationalStatus,perTierSizeUsed,pool,pool.isFASTCacheEnabled,pool.raidType,sizeAllocated,sizeTotal,sizeUsed,smpBackendId,snapCount,snapSchedule,snapWwn,snapsSize,snapsSizeAllocated,storageResource,tieringPolicy,type,wwn",
+      "response": "sv_5608.json"
     }
   ]
 }

--- a/storops_test/unity/rest_data/lun/sv_5608.json
+++ b/storops_test/unity/rest_data/lun/sv_5608.json
@@ -1,0 +1,73 @@
+{
+  "@base": "https://10.109.22.101/api/types/lun/instances?filter=name eq \"RestLun101\"&fields=auSize,creationTime,currentNode,defaultNode,description,health,hostAccess,id,instanceId,isReplicationDestination,isSnapSchedulePaused,isThinEnabled,lunGroupObjectId,metadataSize,metadataSizeAllocated,modificationTime,name,objectId,operationalStatus,perTierSizeUsed,sizeAllocated,sizeTotal,sizeUsed,smpBackendId,snapCount,snapWwn,snapsSize,snapsSizeAllocated,tieringPolicy,type,wwn,snapSchedule.id,storageResource.id,pool.id,ioLimitPolicy.id&per_page=2000&compact=true",
+  "updated": "2016-05-16T07:58:28.009Z",
+  "links": [
+    {
+      "rel": "self",
+      "href": "&page=1"
+    }
+  ],
+  "entries": [
+    {
+      "content": {
+        "id": "sv_5608",
+        "operationalStatus": [
+          2
+        ],
+        "type": 2,
+        "tieringPolicy": 1,
+        "defaultNode": 1,
+        "currentNode": 1,
+        "auSize": 8192,
+        "instanceId": "root/emc:EMC_UEM_StorageVolumeLeaf%InstanceID=sv_5607",
+        "creationTime": "2016-05-16T06:28:42.000Z",
+        "health": {
+          "value": 5,
+          "descriptionIds": [
+            "ALRT_VOL_OK"
+          ],
+          "descriptions": [
+            "The LUN is operating normally. No action is required."
+          ]
+        },
+        "name": "test_thin_clone",
+        "description": "Please specify Lun description",
+        "modificationTime": "2016-05-16T06:29:40.803Z",
+        "sizeTotal": 1073741824,
+        "sizeAllocated": 1073741824,
+        "perTierSizeUsed": [
+          0,
+          0,
+          4294967296
+        ],
+        "isThinEnabled": false,
+        "wwn": "60:06:01:60:24:10:3E:00:9A:68:39:57:0D:65:04:B0",
+        "isReplicationDestination": false,
+        "isSnapSchedulePaused": false,
+        "objectId": 42949674097,
+        "metadataSize": 3489660928,
+        "metadataSizeAllocated": 3221225472,
+        "snapWwn": "60:06:01:60:24:10:3E:00:CE:68:39:57:00:33:8B:B4",
+        "snapsSize": 0,
+        "snapsSizeAllocated": 0,
+        "hostAccess": [
+          {
+            "accessMask": 1,
+            "instanceId": "root/emc:EMC_UEM_HostAccessLunAssocLeaf%InstanceID=5607",
+            "host": {
+              "id": "Host_1"
+            }
+          }
+        ],
+        "snapCount": 0,
+        "storageResource": {
+          "id": "sv_5608"
+        },
+        "pool": {
+          "id": "pool_1"
+        },
+        "familyCloneCount": 1
+      }
+    }
+  ]
+}

--- a/storops_test/unity/rest_data/storageResource/delete_has_thinclone.json
+++ b/storops_test/unity/rest_data/storageResource/delete_has_thinclone.json
@@ -1,0 +1,12 @@
+{
+    "error": {
+        "errorCode": 108009078,
+        "httpStatusCode": 409,
+        "messages": [
+            {
+                "en-US": "The specified LUN cannot be deleted because it has one or more dependent thin clones. (Error Code:0x6701676)"
+            }
+        ],
+        "created": "2017-09-30T07:07:10.495Z"
+    }
+}

--- a/storops_test/unity/rest_data/storageResource/index.json
+++ b/storops_test/unity/rest_data/storageResource/index.json
@@ -930,46 +930,49 @@
     {
       "url": "/api/instances/storageResource/sv_2/action/createLunThinClone?compact=True",
       "body": {
-            "name": "test_thin_clone",
-            "snap": {
-              "id": "38654705847"
-            },
-            "description": "This is description."
+        "name": "test_thin_clone",
+        "snap": {
+          "id": "38654705847"
+        },
+        "description": "This is description."
       },
       "response": "thin_clone.json"
     },
     {
       "url": "/api/instances/storageResource/sv_2/action/createLunThinClone?compact=True",
       "body": {
-            "name": "test_thin_clone",
-            "snap": {
-              "id": "38654705847"
-            },
-            "description": "This is description.",
-            "lunParameters": {
-              "ioLimitParameters": {"id": "qp_2"}}
+        "name": "test_thin_clone",
+        "snap": {
+          "id": "38654705847"
+        },
+        "description": "This is description.",
+        "lunParameters": {
+          "ioLimitParameters": {
+            "id": "qp_2"
+          }
+        }
       },
       "response": "thin_clone.json"
     },
     {
       "url": "/api/instances/storageResource/sv_2/action/createLunThinClone?compact=True",
       "body": {
-            "name": "test_thin_clone_limit_exceeded",
-            "snap": {
-              "id": "38654705847"
-            },
-            "description": "This is description."
+        "name": "test_thin_clone_limit_exceeded",
+        "snap": {
+          "id": "38654705847"
+        },
+        "description": "This is description."
       },
       "response": "thin_clone_limit_exceeded.json"
     },
     {
       "url": "/api/instances/storageResource/sv_3338/action/createLunThinClone?compact=True",
       "body": {
-            "name": "test_thin_clone",
-            "snap": {
-              "id": "38654709077"
-            },
-            "description": "This is description."
+        "name": "test_thin_clone",
+        "snap": {
+          "id": "38654709077"
+        },
+        "description": "This is description."
       },
       "response": "thin_clone_auto_delete.json"
     },
@@ -1032,8 +1035,27 @@
     },
     {
       "url": "/api/instances/storageResource/sv_4/action/modifyLun?compact=True",
-      "body": {"lunParameters": {"hostAccess": [{"host": {"id": "Host_9"}, "accessMask": 1}]}},
+      "body": {
+        "lunParameters": {
+          "hostAccess": [
+            {
+              "host": {
+                "id": "Host_9"
+              },
+              "accessMask": 1
+            }
+          ]
+        }
+      },
       "response": "empty.json"
+    },
+    {
+      "url": "/api/instances/storageResource/sv_5608?compact=True",
+      "body": {
+        "forceSnapDeletion": true,
+        "forceVvolDeletion": true
+      },
+      "response": "delete_has_thinclone.json"
     }
   ]
 }


### PR DESCRIPTION
In Cinder, user can delete a base LUN before deleting all its thinclones

This use case will cause an exception 'UnityBaseHasThinCloneError'

In this patch, the error will be caught and base LUN will be put in the
background queue for later deletion.