### PR TITLE
[GH-171]Fix issue when parsing multiple virtual ports

### DIFF
--- a/storops/lib/parser.py
+++ b/storops/lib/parser.py
@@ -113,16 +113,18 @@ class PropDescriptor(PropMapper):
 
     def convert(self, value):
         c = self.converter
+        ret = value
         if c is not None:
             if self.is_parser():
-                value = c.parse_all(value)
+                ret = c.parse_all(value)
             elif self.is_resource_clazz():
-                value = c().update(value)
+                # value is raw output from cli.
+                ret = c().update(value)
             elif self.is_enum() or self.is_enum_list():
-                value = c.parse(value)
+                ret = c.parse(value)
             elif callable(c):
-                value = c(value)
-        return value
+                ret = c(value)
+        return ret
 
     def is_resource_list_clazz(self):
         rsc_list_clz = storops.lib.resource.ResourceList

--- a/storops/vnx/parser_configs.yaml
+++ b/storops/vnx/parser_configs.yaml
@@ -529,8 +529,18 @@ VNXConnectionPort:
     - label: "Flow Control:"
     - label: "Host Window:"
     - label: "Replication Window:"
+    - label: "Available Window Sizes:" # Starts parsing after this key
+      key: virtual_ports
+      converter: VNXConnectionVirtualPortList
+      end_pattern: "(?:SP:|\\Z)"
+
+
+VNXConnectionVirtualPort:
+  data_src: cli
+  properties:
     - label: "Virtual Port ID:"
       converter: to_int
+      is_index: True
     - label: "VLAN ID:"
       converter: to_int
     - label: "IP Address:"

--- a/storops/vnx/resource/port.py
+++ b/storops/vnx/resource/port.py
@@ -63,30 +63,6 @@ class VNXPort(VNXCliResource):
             items.append(str(self.vport_id))
         return '-'.join(items)
 
-    def config_ip(self, ip, mask, gateway, vport_id=None, vlan_id=None):
-        if self.type != VNXPortType.ISCSI:
-            raise TypeError('configure IP only works for iSCSI ports.')
-        if vport_id is None:
-            vport_id = self.vport_id
-
-        out = self._cli.config_iscsi_ip(
-            self.sp, self.port_id, ip, mask, gateway, vport_id=vport_id,
-            vlan_id=vlan_id)
-        raise_if_err(out, default=VNXPortError)
-
-        if vport_id is None:
-            vport_id = 0
-        return VNXConnectionPort(self.sp, self.port_id, vport_id, self._cli)
-
-    def delete_ip(self, vport_id=None):
-        if self.type != VNXPortType.ISCSI:
-            raise TypeError('delete IP only works for iSCSI ports.')
-        if vport_id is None:
-            vport_id = self.vport_id
-
-        out = self._cli.delete_iscsi_ip(self.sp, self.port_id, vport_id)
-        raise_if_err(out, default=VNXPortError)
-
     @classmethod
     def delete_hba(cls, cli, hba_uid):
         out = cli.delete_hba(hba_uid)
@@ -106,8 +82,8 @@ class VNXPort(VNXCliResource):
         return ret
 
     def __hash__(self):
-        return hash('<VNXPort {{sp: {}, port_id: {}, vport_id: {}}}'
-                    .format(self.sp, self.port_id, self.vport_id))
+        return hash('<VNXPort {{sp: {}, port_id: {}}}'
+                    .format(self.sp, self.port_id))
 
     @staticmethod
     def _get_inst_prop(instance, name):
@@ -300,6 +276,51 @@ class VNXConnectionPortList(VNXCliResourceList):
     def _get_raw_resource(self):
         return self._cli.get_connection_port(poll=self.poll)
 
+    def __len__(self):
+        return len(self._virtual_port_list())
+
+    def __iter__(self):
+        return iter(self._virtual_port_list())
+
+    def __getitem__(self, item):
+        return self._virtual_port_list()[item]
+
+    def _virtual_port_list(self):
+        temp_list = super(VNXConnectionPortList, self).list
+        vport_lists = []
+        for item in temp_list:
+            if len(item.virtual_ports):
+                ports = self._flat_vports(item)
+                vport_lists.extend(ports)
+            else:
+                vport = VNXConnectionVirtualPort(
+                    cli=self._cli, sp=item.sp, port_id=item.port_id,
+                    vport_id=item.vport_id)
+                self._set_child_props(item, vport)
+                vport_lists.append(vport)
+        return vport_lists
+
+    def _flat_vports(self, connection_port):
+        """Flat the virtual ports."""
+        vports = []
+        for vport in connection_port.virtual_ports:
+            self._set_child_props(connection_port, vport)
+            vports.append(vport)
+        return vports
+
+    def _set_child_props(self, parent, child):
+        props = parent.property_names()
+        # Ignore virtual_ports for child
+        props = (x for x in props if x != 'virtual_ports')
+        for prop_name in props:
+            setattr(child, prop_name,
+                    getattr(parent, prop_name))
+
+    def get_dict_repr(self, dec=1):
+        items = [item.get_dict_repr(dec - 1) for
+                 item in self._virtual_port_list()]
+        return {self.__class__.__name__: items}
+
 
 class VNXConnectionPort(VNXPort):
     def __init__(self, sp=None, port_id=None, vport_id=None, cli=None):
@@ -308,14 +329,6 @@ class VNXConnectionPort(VNXPort):
         self._port_id = port_id
         self._vport_id = vport_id
         self._cli = cli
-
-    @property
-    def vport_id(self):
-        if self._vport_id is not None:
-            ret = self._vport_id
-        else:
-            ret = self.virtual_port_id
-        return ret
 
     @property
     def type(self):
@@ -338,6 +351,43 @@ class VNXConnectionPort(VNXPort):
         names.append('type')
         return names
 
+    def _get_virtual_port_prop(self, prop_name):
+        if len(self.virtual_ports) == 0:
+            return None
+        elif len(self.virtual_ports) == 1:
+            return getattr(self.virtual_ports[0], prop_name)
+        else:
+            return getattr(self.virtual_ports, prop_name)
+
+    @property
+    def virtual_port_id(self):
+        return self._get_virtual_port_prop('virtual_port_id')
+
+    @property
+    def vport_id(self):
+        return self.virtual_port_id
+
+    @property
+    def vlan_id(self):
+        return self._get_virtual_port_prop('vlan_id')
+
+    @property
+    def ip_address(self):
+        return self._get_virtual_port_prop('ip_address')
+
+    @property
+    def subnet_mask(self):
+        return self._get_virtual_port_prop('subnet_mask')
+
+    @property
+    def gateway_address(self):
+        return self._get_virtual_port_prop('gateway_address')
+
+    @property
+    def initiator_authentication(self):
+        # port = self._get_uniq_virtual_port()
+        return self._get_virtual_port_prop('initiator_authentication')
+
     @classmethod
     def get(cls, cli, sp=None, port_id=None, vport_id=None, port_type=None,
             has_ip=None):
@@ -349,6 +399,27 @@ class VNXConnectionPort(VNXPort):
         else:
             ret = VNXConnectionPortList(cli, sp, port_id, vport_id, port_type,
                                         has_ip)
+        return ret
+
+
+class VNXConnectionVirtualPort(VNXCliResource):
+    def __init__(self, sp=None, port_id=None, vport_id=None, cli=None):
+        super(VNXConnectionVirtualPort, self).__init__()
+        self._sp = sp
+        self._port_id = port_id
+        self._vport_id = vport_id
+        self._cli = cli
+
+    @property
+    def vport_id(self):
+        return self.virtual_port_id
+
+    def property_names(self):
+        ret = super(VNXConnectionVirtualPort, self).property_names()
+        ret.extend(['auto_negotiate', 'available_speed', 'current_mtu',
+                    'enode_mac_address', 'flow_control', 'host_window',
+                    'iscsi_alias', 'port_id', 'port_speed',
+                    'replication_window', 'sp', 'wwn', 'type'])
         return ret
 
     def ping_node(self, address, packet_size=None, count=None, timeout=None,
@@ -366,6 +437,43 @@ class VNXConnectionPort(VNXPort):
         except VNXPingNodeSuccess:
             # ping success, pass
             pass
+
+    def config_ip(self, ip, mask, gateway, vport_id=None, vlan_id=None):
+        if self.type != VNXPortType.ISCSI:
+            raise TypeError('configure IP only works for iSCSI ports.')
+        if vport_id is None:
+            vport_id = self.virtual_port_id
+
+        out = self._cli.config_iscsi_ip(
+            self.sp, self.port_id, ip, mask, gateway, vport_id=vport_id,
+            vlan_id=vlan_id)
+        raise_if_err(out, default=VNXPortError)
+
+        if vport_id is None:
+            vport_id = 0
+        return VNXConnectionPort(self.sp, self.port_id, vport_id, self._cli)
+
+    def delete_ip(self, vport_id=None):
+        if self.type != VNXPortType.ISCSI:
+            raise TypeError('delete IP only works for iSCSI ports.')
+        if vport_id is None:
+            vport_id = self.virtual_port_id
+
+        out = self._cli.delete_iscsi_ip(self.sp, self.port_id, vport_id)
+        raise_if_err(out, default=VNXPortError)
+
+    @property
+    def display_name(self):
+        items = [self.sp.display_name, str(self.port_id)]
+        if self.vport_id is not None:
+            items.append(str(self.vport_id))
+        return '-'.join(items)
+
+
+class VNXConnectionVirtualPortList(VNXCliResourceList):
+    @classmethod
+    def get_resource_class(cls):
+        return VNXConnectionVirtualPort
 
 
 class VNXStorageGroupHBA(VNXPort):

--- a/storops_test/vnx/resource/test_port.py
+++ b/storops_test/vnx/resource/test_port.py
@@ -238,12 +238,12 @@ class VNXConnectionPortTest(TestCase):
     @patch_cli
     def test_get_all(self):
         ports = VNXConnectionPort.get(t_cli())
-        assert_that(len(ports), equal_to(20))
+        assert_that(len(ports), equal_to(22))
 
     @patch_cli
     def test_get_by_sp(self):
         ports = VNXConnectionPort.get(t_cli(), VNXSPEnum.SP_A)
-        assert_that(len(ports), equal_to(10))
+        assert_that(len(ports), equal_to(12))
 
     @patch_cli
     def test_get_by_port(self):
@@ -253,7 +253,7 @@ class VNXConnectionPortTest(TestCase):
     @patch_cli
     def test_get_by_type(self):
         ports = VNXConnectionPort.get(t_cli(), port_type=VNXPortType.ISCSI)
-        assert_that(len(ports), equal_to(16))
+        assert_that(len(ports), equal_to(18))
         ports = VNXConnectionPort.get(t_cli(), port_type=VNXPortType.FCOE)
         assert_that(len(ports), equal_to(4))
 
@@ -264,6 +264,8 @@ class VNXConnectionPortTest(TestCase):
         port = ports[0]
         assert_that(port.port_id, equal_to(4))
         assert_that(port.sp, equal_to(VNXSPEnum.SP_A))
+        assert_that(port.virtual_port_id, equal_to(0))
+        assert_that(port.vport_id, equal_to(0))
 
     @patch_cli
     def test_get_port_not_found(self):
@@ -324,6 +326,11 @@ class VNXConnectionPortTest(TestCase):
             port.delete_ip()
 
         assert_that(f, raises(VNXVirtualPortNotFoundError, 'not found'))
+
+    @patch_cli
+    def test_port_display_name(self):
+        port = VNXConnectionPort.get(t_cli(), VNXSPEnum.SP_A, 9, 0)
+        assert_that('A-10-0', port.display_name)
 
 
 def test_hba():

--- a/storops_test/vnx/testdata/block_output/connection_-getport_-all.txt
+++ b/storops_test/vnx/testdata/block_output/connection_-getport_-all.txt
@@ -114,6 +114,20 @@ Subnet Mask:  255.255.255.0
 Gateway Address:  0.0.0.0
 Initiator Authentication:  false
 
+Virtual Port ID:  1
+VLAN ID:  3301
+IP Address:  192.168.106.1
+Subnet Mask:  255.255.255.0
+Gateway Address:  0.0.0.0
+Initiator Authentication:  false
+
+Virtual Port ID:  2
+VLAN ID:  3991
+IP Address:  192.168.16.1
+Subnet Mask:  255.255.255.0
+Gateway Address:  0.0.0.0
+Initiator Authentication:  false
+
 SP:  A
 Port ID:  8
 Port WWN:  iqn.1992-04.com.emc:cx.apm00153906536.a8

--- a/storops_test/vnx/testdata/block_output/connection_-getport_-all_-sp_a_-portid_5_-vportid_2.txt
+++ b/storops_test/vnx/testdata/block_output/connection_-getport_-all_-sp_a_-portid_5_-vportid_2.txt
@@ -1,0 +1,21 @@
+SP:  A
+Port ID:  5
+Port WWN:  iqn.1992-04.com.emc:cx.apm00153906536.a5
+iSCSI Alias:  6536.a5
+Enode MAC Address:  00-60-16-45-5D-FC
+Port Speed:  10000 Mb
+Auto-Negotiate:  No
+Available Speeds:  10000 Mb
+Current MTU:  1500
+Available MTU Sizes:  "1260","1448","1500","1548","2000","2450","3000","4000","4080","4470","5000","6000","7000","8000","9000"
+Flow Control:  Auto
+Host Window:  256K
+Replication Window:  256K
+Available Window Sizes:  64K,128K,256K,512K,1MB
+
+Virtual Port ID:  2
+VLAN ID:  3991
+IP Address:  192.168.16.1
+Subnet Mask:  255.255.255.0
+Gateway Address:  0.0.0.0
+Initiator Authentication:  false


### PR DESCRIPTION
When multiple virtual ports are configured on each VNX port, the storops
only returns the first virtual port and ignore all the left ports due
to a parsing issue.

Additionally, This issue causes the Cinder failure when virtual
ports whose virtual port id is larger than zero are configured in
cinder.conf.

This fix provides a new object "VNXConnectVirtualPort" which provides
both port information as well as the virtual port information.