### PR TITLE
[GH-172]Registered ports are not returned from SG.

### DIFF
--- a/storops/vnx/parser_configs.yaml
+++ b/storops/vnx/parser_configs.yaml
@@ -501,6 +501,7 @@ VNXStorageGroupHBA:
       key: hba
     - label: "Host name:"
     - label: "SPPort:"
+      is_index: True
     - label: "Initiator IP:"
     - label: "TPGT:"
     - label: "ISID:"

--- a/storops/vnx/resource/port.py
+++ b/storops/vnx/resource/port.py
@@ -247,7 +247,7 @@ class VNXHbaPort(VNXPort):
     @staticmethod
     def from_storage_group_hba(sg_hba):
         port = VNXHbaPort.create(sg_hba.sp, sg_hba.port_id,
-                                 vport_id=sg_hba.vlan)
+                                 vport_id=sg_hba.vport_id)
         port._host_initiator_list.append(sg_hba.hba[0])
         return port
 
@@ -260,6 +260,11 @@ class VNXHbaPort(VNXPort):
     def property_names(self):
         return ['sp', 'port_id', 'vport_id', 'type',
                 'host_initiator_list']
+
+    def __hash__(self):
+        return hash('<VNXPort {{sp: {}, port_id: {}, vport_id: {}}}'
+                    .format(self.sp, self.port_id,
+                            self.vport_id if self.vport_id else None))
 
 
 class VNXConnectionPortList(VNXCliResourceList):
@@ -381,8 +386,19 @@ class VNXStorageGroupHBA(VNXPort):
     def uid(self):
         return self.hba[0]
 
+    # @property
+    # def vlan(self):
+    #     sp_port = self.sp_port
+    #     ret = None
+    #
+    #     if self.type == VNXPortType.ISCSI:
+    #         # vport only valid for iSCSI
+    #         if sp_port is not None and 'v' in sp_port:
+    #             ret = int(sp_port[sp_port.find('v') + 1:])
+    #     return ret
+
     @property
-    def vlan(self):
+    def vport_id(self):
         sp_port = self.sp_port
         ret = None
 
@@ -391,10 +407,6 @@ class VNXStorageGroupHBA(VNXPort):
             if sp_port is not None and 'v' in sp_port:
                 ret = int(sp_port[sp_port.find('v') + 1:])
         return ret
-
-    @property
-    def vport_id(self):
-        return self.vlan
 
     @property
     def port_type(self):

--- a/storops_test/vnx/resource/test_port.py
+++ b/storops_test/vnx/resource/test_port.py
@@ -347,8 +347,8 @@ class VNXStorageGroupHBATest(TestCase):
     def test_port_id(self):
         assert_that(test_hba().port_id, equal_to(3))
 
-    def test_vlan(self):
-        assert_that(test_hba().vlan, equal_to(1))
+    def test_vport_id(self):
+        assert_that(test_hba().vport_id, equal_to(1))
 
     def test_port_type(self):
         assert_that(test_hba().port_type,

--- a/storops_test/vnx/resource/test_sg.py
+++ b/storops_test/vnx/resource/test_sg.py
@@ -161,18 +161,14 @@ class VNXStorageGroupTest(TestCase):
     @patch_cli
     def test_get_sg_os01(self):
         sg = VNXStorageGroup(name='os01', cli=t_cli())
-        assert_that(len(sg.hba_sp_pairs), equal_to(1))
+        # The hba pare is incomplete, should be 0
+        assert_that(len(sg.hba_sp_pairs), equal_to(0))
         assert_that(sg.hba_sp_pairs, instance_of(VNXStorageGroupHBAList))
-        hba = sg.hba_sp_pairs[0]
-        assert_that(hba.sp, equal_to(VNXSPEnum.SP_A))
-        assert_that(hba.uid,
-                    equal_to('iqn.1993-08.org.debian:01:95bbe389e025'))
-        assert_that(hba.port_id, equal_to(4))
 
     @patch_cli
     def test_initiator_uid_list(self):
         sg = get_sg('microsoft')
-        assert_that(len(sg.initiator_uid_list), equal_to(2))
+        assert_that(len(sg.initiator_uid_list), equal_to(1))
         assert_that(sg.initiator_uid_list,
                     has_item('iqn.1991-05.com.microsoft:abc.def.dev'))
 
@@ -221,6 +217,13 @@ class VNXStorageGroupTest(TestCase):
         assert_that(len(ports), equal_to(6))
         for port in ports:
             assert_that(port.host_initiator_list, has_item(wwn))
+
+    @patch_cli
+    def test_get_ports_by_iqn(self):
+        iqn = 'iqn.2005-03.org.open-iscsi:bdbc466e1af3'
+        ubuntu16 = get_sg('ubuntu16')
+        ports = ubuntu16.get_ports(iqn)
+        assert_that(len(ports), equal_to(3))
 
     @patch_cli
     def test_get_ports_no_wwn(self):

--- a/storops_test/vnx/test_parsers.py
+++ b/storops_test/vnx/test_parsers.py
@@ -217,7 +217,7 @@ class VNXStorageGroupParserTest(TestCase):
         assert_that(sg.alu_hlu_map.get(3, None), none())
 
         # assert for hba members
-        assert_that(len(sg.hba_sp_pairs), equal_to(3))
+        assert_that(len(sg.hba_sp_pairs), equal_to(2))
         hba = sg.hba_sp_pairs[0]
         assert_that(hba.host_name, equal_to('abc.def.dev'))
 

--- a/storops_test/vnx/testdata/block_output/storagegroup_-messner_-list_-host_-iscsiAttributes_-gname_ubuntu16.txt
+++ b/storops_test/vnx/testdata/block_output/storagegroup_-messner_-list_-host_-iscsiAttributes_-gname_ubuntu16.txt
@@ -1,0 +1,28 @@
+Storage Group Name:    ubuntu16
+Storage Group UID:     F8:01:E8:34:9C:6B:E7:11:87:54:80:93:0D:9B:3E:61
+HBA/SP Pairs:
+
+  HBA UID                                          SP Name     SPPort
+  -------                                          -------     ------
+  iqn.2005-03.org.open-iscsi:bdbc466e1af3           SP A         12
+Host name:             ubuntu16
+SPPort:                A-12v0
+Initiator IP:          192.168.3.30
+TPGT:                  3
+ISID:                  43D0200
+
+  iqn.2005-03.org.open-iscsi:bdbc466e1af3           SP B         12
+Host name:             ubuntu16
+SPPort:                B-12v0
+Initiator IP:          192.168.3.30
+TPGT:                  4
+ISID:                  13D0200
+
+  iqn.2005-03.org.open-iscsi:bdbc466e1af3           SP B         12
+Host name:             ubuntu16
+SPPort:                B-12v1
+Initiator IP:          N/A
+TPGT:                  5
+ISID:                  N/A
+
+Shareable:             YES


### PR DESCRIPTION
Currently if multiple virtual ports are registerred on a storage group,
Only one virtual port can be fetch from sg.get_ports() due to a logic
filterring error.

This causes an incomplete port list returned to cinder, and a volume
attachment error may occurs.