### PR TITLE
Fix ping_node issue

### DIFF
--- a/storops/exception.py
+++ b/storops/exception.py
@@ -253,7 +253,7 @@ def check_nas_cmd_error(output, default=None):
     except VNXNasCommandNoError:
         # meaning no error
         pass
-    except:
+    except: # noqa
         # re-raise the error
         raise
 

--- a/storops/unity/resource/host.py
+++ b/storops/unity/resource/host.py
@@ -208,7 +208,7 @@ class UnityHost(UnityResource):
         except ex.UnityAttachExceedLimitError:
             # The number of luns exceeds system limit
             raise
-        except:
+        except: # noqa
             # other attach error, remove this lun if already attached
             self.detach(lun_or_snap)
             raise
@@ -227,7 +227,7 @@ class UnityHost(UnityResource):
         except ex.UnityAttachAluExceedLimitError:
             # The number of luns exceeds system limit
             raise
-        except:
+        except: # noqa
             # other attach error, remove this lun if already attached
             self.detach_alu(lun)
             raise

--- a/storops/unity/resource/storage_resource.py
+++ b/storops/unity/resource/storage_resource.py
@@ -67,7 +67,7 @@ class UnityConsistencyGroup(UnityResource):
             resp.raise_if_err()
         except UnityStorageResourceNameInUseError:
             raise UnityConsistencyGroupNameInUseError()
-        except:
+        except: # noqa
             raise
 
         return UnityConsistencyGroup(_id=resp.resource_id, cli=cli)

--- a/storops_test/vnx/resource/test_lun.py
+++ b/storops_test/vnx/resource/test_lun.py
@@ -56,66 +56,66 @@ class VNXLunTest(TestCase):
     @patch_cli
     def test_lun_properties(self):
         wwn = '60:06:01:60:12:60:3D:00:95:63:38:87:9D:69:E5:11'
-        l = VNXLun(lun_id=3, cli=t_cli())
-        assert_that(l.state, equal_to('Ready'))
-        assert_that(l.wwn, equal_to(wwn))
-        assert_that(l.status, equal_to('OK(0x0)'))
-        assert_that(l.operation, equal_to('None'))
-        assert_that(l.total_capacity_gb, equal_to(500.0))
-        assert_that(l.current_owner, equal_to(VNXSPEnum.SP_A))
-        assert_that(l.default_owner, equal_to(VNXSPEnum.SP_A))
-        assert_that(l.attached_snapshot, none())
-        assert_that(l.lun_id, equal_to(3))
-        assert_that(l.name, equal_to('File_CS0_21132_0_d7'))
-        assert_that(l.pool_name, equal_to('Pool4File'))
-        assert_that(l.is_thin_lun, equal_to(True))
-        assert_that(l.is_compressed, equal_to(False))
-        assert_that(l.is_dedup, equal_to(False))
-        assert_that(l.initial_tier, equal_to('Optimize Pool'))
-        assert_that(l.tiering_policy, none())
-        assert_that(l.is_private, equal_to(False))
-        assert_that(l.user_capacity_gbs, equal_to(500.0))
-        assert_that(l.consumed_capacity_gbs, equal_to(512.249))
-        assert_that(len(l.snapshot_mount_points), equal_to(0))
-        assert_that(l.primary_lun, none())
-        assert_that(l.raid_type, equal_to(VNXPoolRaidType.RAID_MIXED))
+        lun = VNXLun(lun_id=3, cli=t_cli())
+        assert_that(lun.state, equal_to('Ready'))
+        assert_that(lun.wwn, equal_to(wwn))
+        assert_that(lun.status, equal_to('OK(0x0)'))
+        assert_that(lun.operation, equal_to('None'))
+        assert_that(lun.total_capacity_gb, equal_to(500.0))
+        assert_that(lun.current_owner, equal_to(VNXSPEnum.SP_A))
+        assert_that(lun.default_owner, equal_to(VNXSPEnum.SP_A))
+        assert_that(lun.attached_snapshot, none())
+        assert_that(lun.lun_id, equal_to(3))
+        assert_that(lun.name, equal_to('File_CS0_21132_0_d7'))
+        assert_that(lun.pool_name, equal_to('Pool4File'))
+        assert_that(lun.is_thin_lun, equal_to(True))
+        assert_that(lun.is_compressed, equal_to(False))
+        assert_that(lun.is_dedup, equal_to(False))
+        assert_that(lun.initial_tier, equal_to('Optimize Pool'))
+        assert_that(lun.tiering_policy, none())
+        assert_that(lun.is_private, equal_to(False))
+        assert_that(lun.user_capacity_gbs, equal_to(500.0))
+        assert_that(lun.consumed_capacity_gbs, equal_to(512.249))
+        assert_that(len(lun.snapshot_mount_points), equal_to(0))
+        assert_that(lun.primary_lun, none())
+        assert_that(lun.raid_type, equal_to(VNXPoolRaidType.RAID_MIXED))
 
     @patch_cli
     def test_lun_perf_counters(self):
-        l = VNXLun(lun_id=3, cli=t_cli())
-        assert_that(l.read_requests, equal_to(1))
-        assert_that(l.read_requests_sp_a, equal_to(2))
-        assert_that(l.read_requests_sp_b, equal_to(3))
-        assert_that(l.write_requests, equal_to(4))
-        assert_that(l.write_requests_sp_a, equal_to(5))
-        assert_that(l.write_requests_sp_b, equal_to(6))
-        assert_that(l.blocks_read, equal_to(7))
-        assert_that(l.blocks_read_sp_a, equal_to(8))
-        assert_that(l.blocks_read_sp_b, equal_to(9))
-        assert_that(l.blocks_written, equal_to(10))
-        assert_that(l.blocks_written_sp_a, equal_to(11))
-        assert_that(l.blocks_written_sp_b, equal_to(12))
-        assert_that(l.busy_ticks, equal_to(13))
-        assert_that(l.busy_ticks_sp_a, equal_to(14))
-        assert_that(l.busy_ticks_sp_b, equal_to(15))
-        assert_that(l.idle_ticks, equal_to(16))
-        assert_that(l.idle_ticks_sp_a, equal_to(17))
-        assert_that(l.idle_ticks_sp_b, equal_to(18))
-        assert_that(l.sum_of_outstanding_requests, equal_to(19))
-        assert_that(l.sum_of_outstanding_requests_sp_a, equal_to(20))
-        assert_that(l.sum_of_outstanding_requests_sp_b, equal_to(21))
-        assert_that(l.non_zero_request_count_arrivals, equal_to(22))
-        assert_that(l.non_zero_request_count_arrivals_sp_a, equal_to(23))
-        assert_that(l.non_zero_request_count_arrivals_sp_b, equal_to(24))
-        assert_that(l.implicit_trespasses, equal_to(25))
-        assert_that(l.implicit_trespasses_sp_a, equal_to(26))
-        assert_that(l.implicit_trespasses_sp_b, equal_to(27))
-        assert_that(l.explicit_trespasses, equal_to(28))
-        assert_that(l.explicit_trespasses_sp_a, equal_to(29))
-        assert_that(l.explicit_trespasses_sp_b, equal_to(30))
-        assert_that(l.extreme_performance, equal_to(1.96))
-        assert_that(l.performance, equal_to(5.68))
-        assert_that(l.capacity, equal_to(92.37))
+        lun = VNXLun(lun_id=3, cli=t_cli())
+        assert_that(lun.read_requests, equal_to(1))
+        assert_that(lun.read_requests_sp_a, equal_to(2))
+        assert_that(lun.read_requests_sp_b, equal_to(3))
+        assert_that(lun.write_requests, equal_to(4))
+        assert_that(lun.write_requests_sp_a, equal_to(5))
+        assert_that(lun.write_requests_sp_b, equal_to(6))
+        assert_that(lun.blocks_read, equal_to(7))
+        assert_that(lun.blocks_read_sp_a, equal_to(8))
+        assert_that(lun.blocks_read_sp_b, equal_to(9))
+        assert_that(lun.blocks_written, equal_to(10))
+        assert_that(lun.blocks_written_sp_a, equal_to(11))
+        assert_that(lun.blocks_written_sp_b, equal_to(12))
+        assert_that(lun.busy_ticks, equal_to(13))
+        assert_that(lun.busy_ticks_sp_a, equal_to(14))
+        assert_that(lun.busy_ticks_sp_b, equal_to(15))
+        assert_that(lun.idle_ticks, equal_to(16))
+        assert_that(lun.idle_ticks_sp_a, equal_to(17))
+        assert_that(lun.idle_ticks_sp_b, equal_to(18))
+        assert_that(lun.sum_of_outstanding_requests, equal_to(19))
+        assert_that(lun.sum_of_outstanding_requests_sp_a, equal_to(20))
+        assert_that(lun.sum_of_outstanding_requests_sp_b, equal_to(21))
+        assert_that(lun.non_zero_request_count_arrivals, equal_to(22))
+        assert_that(lun.non_zero_request_count_arrivals_sp_a, equal_to(23))
+        assert_that(lun.non_zero_request_count_arrivals_sp_b, equal_to(24))
+        assert_that(lun.implicit_trespasses, equal_to(25))
+        assert_that(lun.implicit_trespasses_sp_a, equal_to(26))
+        assert_that(lun.implicit_trespasses_sp_b, equal_to(27))
+        assert_that(lun.explicit_trespasses, equal_to(28))
+        assert_that(lun.explicit_trespasses_sp_a, equal_to(29))
+        assert_that(lun.explicit_trespasses_sp_b, equal_to(30))
+        assert_that(lun.extreme_performance, equal_to(1.96))
+        assert_that(lun.performance, equal_to(5.68))
+        assert_that(lun.capacity, equal_to(92.37))
 
     @patch_cli
     def test_lun_state_properties(self):
@@ -368,40 +368,40 @@ class VNXLunTest(TestCase):
 
     @patch_cli
     def test_change_name(self):
-        l = VNXLun(name='m1', cli=t_cli())
-        l.name = 'l1'
-        assert_that(l.name, equal_to('l1'))
+        lun = VNXLun(name='m1', cli=t_cli())
+        lun.name = 'l1'
+        assert_that(lun.name, equal_to('l1'))
 
     @patch_cli
     def test_change_name_not_found(self):
         def f():
-            l = VNXLun(lun_id=4000, cli=t_cli())
-            l.name = 'l1'
+            lun = VNXLun(lun_id=4000, cli=t_cli())
+            lun.name = 'l1'
 
         assert_that(f, raises(VNXLunNotFoundError, 'may not exist'))
 
     @patch_cli
     def test_change_name_failed(self):
-        l = VNXLun(name='l1', cli=t_cli())
+        lun = VNXLun(name='l1', cli=t_cli())
         try:
-            l.name = 'l3'
+            lun.name = 'l3'
             self.fail('should have raised an exception.')
         except VNXNameInUseError:
-            assert_that(l._get_name(), equal_to('l1'))
+            assert_that(lun._get_name(), equal_to('l1'))
 
     @patch_cli
     def test_change_tier(self):
         def f():
-            l = VNXLun(lun_id=4000, cli=t_cli())
-            l.tier = VNXTieringEnum.LOW
+            lun = VNXLun(lun_id=4000, cli=t_cli())
+            lun.tier = VNXTieringEnum.LOW
 
         assert_that(f, raises(VNXLunNotFoundError, 'may not exist'))
 
     @patch_cli
     def test_expand_too_large(self):
         def f():
-            l = VNXLun(lun_id=0, cli=t_cli())
-            l.expand(999999)
+            lun = VNXLun(lun_id=0, cli=t_cli())
+            lun.expand(999999)
 
         assert_that(f, raises(VNXLunExtendError,
                               'capacity specified is not supported'))
@@ -409,8 +409,8 @@ class VNXLunTest(TestCase):
     @patch_cli
     def test_expand_file_lun(self):
         def f():
-            l = VNXLun(lun_id=1, cli=t_cli())
-            l.expand(500)
+            lun = VNXLun(lun_id=1, cli=t_cli())
+            lun.expand(500)
 
         assert_that(f, raises(VNXLunExtendError,
                               'affect a File System Storage'))
@@ -418,8 +418,8 @@ class VNXLunTest(TestCase):
     @patch_cli
     def test_expand_too_small(self):
         def f():
-            l = VNXLun(lun_id=1, cli=t_cli())
-            l.expand(1)
+            lun = VNXLun(lun_id=1, cli=t_cli())
+            lun.expand(1)
 
         assert_that(f, raises(VNXLunExpandSizeError,
                               'greater than current LUN size'))
@@ -427,8 +427,8 @@ class VNXLunTest(TestCase):
     @patch_cli
     def test_expand_preparing(self):
         def f():
-            l = VNXLun(lun_id=1, cli=t_cli())
-            l.expand(12)
+            lun = VNXLun(lun_id=1, cli=t_cli())
+            lun.expand(12)
 
         assert_that(f, raises(VNXLunPreparingError,
                               "is 'Preparing"))
@@ -561,15 +561,15 @@ class VNXLunTest(TestCase):
 
     @patch_cli
     def test_delete_lun_has_smp_force(self):
-        l = VNXLun(lun_id=196, cli=t_cli())
+        lun = VNXLun(lun_id=196, cli=t_cli())
         # no error raised
-        l.delete(force=True)
+        lun.delete(force=True)
 
     @patch_cli
     def test_delete_lun_has_migration(self):
         def f():
-            l = VNXLun(name='lun_in_migration', cli=t_cli())
-            l.delete()
+            lun = VNXLun(name='lun_in_migration', cli=t_cli())
+            lun.delete()
 
         assert_that(f, raises(VNXLunUsedByFeatureError,
                               'Cannot unbind LUN'))
@@ -604,26 +604,26 @@ class VNXLunTest(TestCase):
 
     @patch_cli
     def test_create_mirror_view(self):
-        l = VNXLun(lun_id=245, cli=t_cli())
-        mv = l.create_mirror_view('mv0')
+        lun = VNXLun(lun_id=245, cli=t_cli())
+        mv = lun.create_mirror_view('mv0')
         assert_that(mv.state, equal_to('Active'))
 
     @patch_cli
     def test_get_source_mirror_view(self):
-        l = self.get_lun()
-        assert_that(len(l.get_mirror_view(as_src=True)), equal_to(1))
+        lun = self.get_lun()
+        assert_that(len(lun.get_mirror_view(as_src=True)), equal_to(1))
 
     @patch_cli
     def test_get_target_mirror_view(self):
-        l = self.get_lun()
-        assert_that(len(l.get_mirror_view(as_tgt=True)), equal_to(2))
+        lun = self.get_lun()
+        assert_that(len(lun.get_mirror_view(as_tgt=True)), equal_to(2))
 
     @patch_cli
     def test_get_mirror_view_all(self):
-        l = self.get_lun()
-        assert_that(len(l.get_mirror_view(as_src=True, as_tgt=True)),
+        lun = self.get_lun()
+        assert_that(len(lun.get_mirror_view(as_src=True, as_tgt=True)),
                     equal_to(3))
-        assert_that(len(l.get_mirror_view()), equal_to(3))
+        assert_that(len(lun.get_mirror_view()), equal_to(3))
 
     @patch_cli
     def test_force_delete_lun_not_found(self):

--- a/storops_test/vnx/resource/test_port.py
+++ b/storops_test/vnx/resource/test_port.py
@@ -63,7 +63,6 @@ class VNXSPPortTest(TestCase):
         port = VNXSPPort.get(t_cli(), VNXSPEnum.SP_A, 0)[0]
         assert_that(port.sp, equal_to(VNXSPEnum.SP_A))
         assert_that(port.port_id, equal_to(0))
-        assert_that(port.vport_id, none())
         assert_that(port.index, equal_to('A_0'))
         assert_that(port.wwn, equal_to(
             '50:06:01:60:B6:E0:16:81:50:06:01:60:36:E0:16:81'))
@@ -258,7 +257,7 @@ class VNXConnectionPortTest(TestCase):
         assert_that(len(ports), equal_to(4))
 
     @patch_cli
-    def test_get_single(self):
+    def test_get_by_sp_port_id(self):
         ports = VNXConnectionPort.get(t_cli(), VNXSPEnum.SP_A, 4)
         assert_that(len(ports), equal_to(1))
         port = ports[0]
@@ -266,6 +265,14 @@ class VNXConnectionPortTest(TestCase):
         assert_that(port.sp, equal_to(VNXSPEnum.SP_A))
         assert_that(port.virtual_port_id, equal_to(0))
         assert_that(port.vport_id, equal_to(0))
+
+    @patch_cli
+    def test_get_single(self):
+        port = VNXConnectionPort.get(t_cli(), VNXSPEnum.SP_A, 5, 2)
+        assert_that(port.port_id, equal_to(5))
+        assert_that(port.sp, equal_to(VNXSPEnum.SP_A))
+        assert_that(port.virtual_port_id, equal_to(2))
+        assert_that(port.vport_id, equal_to(2))
 
     @patch_cli
     def test_get_port_not_found(self):
@@ -329,7 +336,7 @@ class VNXConnectionPortTest(TestCase):
 
     @patch_cli
     def test_port_display_name(self):
-        port = VNXConnectionPort.get(t_cli(), VNXSPEnum.SP_A, 9, 0)
+        port = VNXConnectionPort.get(t_cli(), VNXSPEnum.SP_A, 5, 0)
         assert_that('A-10-0', port.display_name)
 
 

--- a/storops_test/vnx/resource/test_system.py
+++ b/storops_test/vnx/resource/test_system.py
@@ -261,6 +261,13 @@ class VNXSystemTest(TestCase):
         assert_that(len(ports), equal_to(4))
 
     @patch_cli
+    def test_ping_node(self):
+        port = self.vnx.get_iscsi_port(sp=VNXSPEnum.SP_A, port_id=5,
+                                       vport_id=2)
+        port.ping_node('192.168.1.50')
+        assert_that('A-5-2', port.display_name)
+
+    @patch_cli
     def test_get_fcoe_port_all(self):
         ports = self.vnx.get_fcoe_port()
         assert_that(ports, instance_of(VNXConnectionPortList))

--- a/storops_test/vnx/testdata/block_output/connection_-pingnode_-sp_a_-portid_5_-vportid_2_-address_192.168.1.50.txt
+++ b/storops_test/vnx/testdata/block_output/connection_-pingnode_-sp_a_-portid_5_-vportid_2_-address_192.168.1.50.txt
@@ -1,0 +1,4 @@
+Reply from 192.168.1.50:  bytes=32 time=140ms TTL=30
+Reply from 192.168.1.50:  bytes=32 time=1ms TTL=30
+Reply from 192.168.1.50:  bytes=32 time=61ms TTL=30
+Reply from 192.168.1.50:  bytes=32 time=1ms TTL=30


### PR DESCRIPTION
this patch fix following error when calling port.ping_node('ip')

AttributeError: 'VNXConnectionPort' does not contain attribute
'ping_node'