### PR TITLE
Refine snap restore API for Unity

### DIFF
--- a/storops/unity/resource/snap.py
+++ b/storops/unity/resource/snap.py
@@ -120,12 +120,25 @@ class UnitySnap(UnityResource):
         resp.raise_if_err()
         return resp
 
-    def restore(self, backup=None):
+    def restore(self, backup=None, delete_backup=False):
+        """Restore the snapshot to the associated storage resource.
+
+        :param backup: name of the backup snapshot
+        :param delete_backup: Whether to delete the backup snap after a
+                              successful restore.
+        """
         resp = self._cli.action(self.resource_class, self.get_id(),
                                 'restore', copyName=backup)
         resp.raise_if_err()
         backup = resp.first_content['backup']
-        return UnitySnap(_id=backup['id'], cli=self._cli)
+        backup_snap = UnitySnap(_id=backup['id'], cli=self._cli)
+
+        if delete_backup:
+            log.info("Deleting the backup snap {} as the restoration "
+                     "succeeded.".format(backup['id']))
+            backup_snap.delete()
+
+        return backup_snap
 
     def is_cg_snap(self):
         cg_type = enums.StorageResourceTypeEnum.CONSISTENCY_GROUP

--- a/storops_test/unity/resource/test_snap.py
+++ b/storops_test/unity/resource/test_snap.py
@@ -208,3 +208,15 @@ class UnitySnapTest(TestCase):
                             description='This is description.',
                             io_limit_policy=None)
         assert_that(_inner, raises(UnityException, "Error Code:0x670166b"))
+
+    @patch_rest
+    def test_snap_restore(self):
+        snap = UnitySnap(cli=t_rest(), _id='38654705785')
+        backup = snap.restore(backup="backup_snap", delete_backup=True)
+        assert_that(backup.id, equal_to("38654700002"))
+
+    @patch_rest
+    def test_snap_restore_auto_delete_false(self):
+        snap = UnitySnap(cli=t_rest(), _id='38654705785')
+        backup = snap.restore(backup="backup_snap")
+        assert_that(backup.id, equal_to("38654700002"))

--- a/storops_test/unity/rest_data/snap/backup_response.json
+++ b/storops_test/unity/rest_data/snap/backup_response.json
@@ -1,0 +1,15 @@
+{
+    "@base": "https://10.245.101.39/api/instances/snap",
+    "updated": "2018-01-04T06:01:22.620Z",
+    "links": [
+        {
+            "rel": "self",
+            "href": "/38654700002"
+        }
+    ],
+    "content": {
+        "backup": {
+            "id": "38654700002"
+        }
+    }
+}

--- a/storops_test/unity/rest_data/snap/index.json
+++ b/storops_test/unity/rest_data/snap/index.json
@@ -338,6 +338,15 @@
         "isAutoDelete": false
       },
       "response": "create_38654700001.json"
+    },
+    {
+      "url": "/api/instances/snap/38654705785/action/restore?compact=True",
+      "body": {"copyName": "backup_snap"},
+      "response": "backup_response.json"
+    },
+    {
+      "url": "/api/instances/snap/38654700002?compact=True",
+      "response": "empty.json"
     }
   ]
 }


### PR DESCRIPTION
This commit adds a new parameter ``delete_backup`` to satisfy the
OpenStack Cinder driver requirement.