### PR TITLE
[GH-184]Add filter support to sg list

### DIFF
--- a/storops/vnx/resource/sg.py
+++ b/storops/vnx/resource/sg.py
@@ -366,11 +366,25 @@ class VNXStorageGroupList(VNXCliResourceList):
     def get_resource_class(cls):
         return VNXStorageGroup
 
-    def __init__(self, cli=None, engineering=False, system_lun_list=None):
+    def __init__(self, cli=None, engineering=False, system_lun_list=None,
+                 attached_lun=None):
         super(VNXStorageGroupList, self).__init__(cli)
         self._sg_map = {}
         self._engineering = engineering
         self._system_lun_list = system_lun_list
+
+        self._attached_lun = None
+        self._set_filter(attached_lun)
+
+    def _set_filter(self, attached_lun=None):
+        self._attached_lun = attached_lun
+
+    def _filter(self, sg):
+        if self._attached_lun is not None:
+            ret = self._attached_lun in sg.used_alu_numbers
+        else:
+            ret = True
+        return ret
 
     def add_sg(self, sg):
         self._sg_map[sg.name] = sg

--- a/storops_test/vnx/resource/test_sg.py
+++ b/storops_test/vnx/resource/test_sg.py
@@ -80,6 +80,13 @@ class VNXStorageGroupListTest(TestCase):
         for sg in sgs:
             assert_that(sg.lun_list.timestamp, equal_to(lun_list.timestamp))
 
+    @patch_cli
+    def test_sg_list_shadow_copy(self):
+        filtered_sgs = self.sg_list.shadow_copy(attached_lun=15)
+        assert_that(len(filtered_sgs), equal_to(1))
+        assert_that(len(self.sg_list), equal_to(4))
+        assert_that(filtered_sgs.timestamp, equal_to(self.sg_list.timestamp))
+
 
 def get_sg(name='server7'):
     sg = VNXStorageGroup(name=name, cli=t_cli())


### PR DESCRIPTION
To support Cinder force detach volumes from all hosts, it needs to list
all the storage groups to which the specified LUN is attached.