### PR TITLE
fix bug in parsing host id that are ipv6 enclosed with '[]'

### DIFF
--- a/storops/lib/converter.py
+++ b/storops/lib/converter.py
@@ -267,6 +267,9 @@ def parse_host_address(addr):
     :rtype: (string, int, string)
     """
 
+    if addr.startswith('[') and addr.endswith(']'):
+        addr = addr[1:-1]
+
     parts = addr.split('/')
     if len(parts) == 1:
         return parts[0], None, None

--- a/storops_test/lib/test_converter.py
+++ b/storops_test/lib/test_converter.py
@@ -283,6 +283,14 @@ class ConverterTest(TestCase):
         assert_that(mask, equal_to('ffff:ffff:ffff:ffff:0000:0000:0000:0000'))
         assert_that(prefix, equal_to(64))
 
+    def test_parse_host_address_ipv6_cidr2(self):
+        cidr = '[2001:db8:a0b:12f0::/64]'
+        address, prefix, mask = converter.parse_host_address(cidr)
+        assert_that(address, equal_to('2001:db8:a0b:12f0::'))
+        assert_that(mask,
+                    equal_to('ffff:ffff:ffff:ffff:0000:0000:0000:0000'))
+        assert_that(prefix, equal_to(64))
+
     def test_url_to_mask_ipv6_prefix_63(self):
         cidr = '2001:db8:a0b:12f0::/63'
         address, prefix, mask = converter.parse_host_address(cidr)


### PR DESCRIPTION
the host address can be '[2001:db8:a0b:12f0::/64]' and '2001:db8:a0b:12f0::/64'. This fix is for the ip address with []