### PR TITLE
Allow comparison of different port types

### DIFF
--- a/storops/vnx/resource/port.py
+++ b/storops/vnx/resource/port.py
@@ -263,8 +263,7 @@ class VNXHbaPort(VNXPort):
 
     def __hash__(self):
         return hash('<VNXPort {{sp: {}, port_id: {}, vport_id: {}}}'
-                    .format(self.sp, self.port_id,
-                            self.vport_id if self.vport_id else None))
+                    .format(self.sp, self.port_id, self.vport_id))
 
 
 class VNXConnectionPortList(VNXCliResourceList):
@@ -450,6 +449,10 @@ class VNXConnectionVirtualPort(VNXPort):
                     'iscsi_alias', 'port_id', 'port_speed',
                     'replication_window', 'sp', 'wwn', 'type'])
         return ret
+
+    def __hash__(self):
+        return hash('<VNXPort {{sp: {}, port_id: {}, vport_id: {}}}'
+                    .format(self.sp, self.port_id, self.vport_id))
 
 
 class VNXConnectionVirtualPortList(VNXCliResourceList):

--- a/storops_test/vnx/resource/test_port.py
+++ b/storops_test/vnx/resource/test_port.py
@@ -237,12 +237,12 @@ class VNXConnectionPortTest(TestCase):
     @patch_cli
     def test_get_all(self):
         ports = VNXConnectionPort.get(t_cli())
-        assert_that(len(ports), equal_to(22))
+        assert_that(len(ports), equal_to(23))
 
     @patch_cli
     def test_get_by_sp(self):
         ports = VNXConnectionPort.get(t_cli(), VNXSPEnum.SP_A)
-        assert_that(len(ports), equal_to(12))
+        assert_that(len(ports), equal_to(13))
 
     @patch_cli
     def test_get_by_port(self):
@@ -252,7 +252,7 @@ class VNXConnectionPortTest(TestCase):
     @patch_cli
     def test_get_by_type(self):
         ports = VNXConnectionPort.get(t_cli(), port_type=VNXPortType.ISCSI)
-        assert_that(len(ports), equal_to(18))
+        assert_that(len(ports), equal_to(19))
         ports = VNXConnectionPort.get(t_cli(), port_type=VNXPortType.FCOE)
         assert_that(len(ports), equal_to(4))
 
@@ -507,6 +507,19 @@ class VNXPortTest(TestCase):
         hba = test_hba()
         h_port = VNXHbaPort.create('a', 3, vport_id=1)
         assert_that(hba, equal_to(h_port))
+
+    @patch_cli
+    def test_hba_port_with_connection_port(self):
+        sg = VNXStorageGroup.get(cli=t_cli(), name='microsoft')
+        h_port = sg.get_ports(
+            initiator_uid='iqn.1991-05.com.microsoft:abc.def.dev')
+        c_port = VNXConnectionPort.get(
+            sp=VNXSPEnum.SP_A, port_id=1, cli=t_cli())
+        assert_that(len(h_port), equal_to(2))
+        r = set(h_port) - {item for item in c_port}
+        assert_that(len(r), equal_to(1))
+        assert_that(list(r)[0].port_id, equal_to(1))
+        assert_that(list(r)[0].sp, equal_to(VNXSPEnum.SP_B))
 
     @patch_cli
     def test_get_metrics_csv(self):

--- a/storops_test/vnx/resource/test_system.py
+++ b/storops_test/vnx/resource/test_system.py
@@ -128,7 +128,7 @@ class VNXSystemTest(TestCase):
     @patch_cli
     def test_connection_port(self):
         ports = self.vnx.get_connection_port()
-        assert_that(len(ports), equal_to(22))
+        assert_that(len(ports), equal_to(23))
         assert_that(ports, instance_of(VNXConnectionPortList))
         for x in ports:
             assert_that(x, instance_of(VNXConnectionVirtualPort))

--- a/storops_test/vnx/testdata/block_output/connection_-getport_-all.txt
+++ b/storops_test/vnx/testdata/block_output/connection_-getport_-all.txt
@@ -399,3 +399,24 @@ IP Address:  N/A
 Subnet Mask:  N/A
 Gateway Address:  N/A
 Initiator Authentication:  N/A
+
+SP:  A
+Port ID:  1
+Port WWN:  iqn.1992-04.com.emc:cx.apm00153906536.a4
+iSCSI Alias:  6536.a4
+Enode MAC Address:  00-60-16-45-5D-FC
+Port Speed:  10000 Mb
+Auto-Negotiate:  No
+Available Speeds:  10000 Mb
+Current MTU:  1500
+Available MTU Sizes:  "1260","1448","1500","1548","2000","2450","3000","4000","4080","4470","5000","6000","7000","8000","9000"
+Flow Control:  Auto
+Host Window:  256K
+Replication Window:  256K
+Available Window Sizes:  64K,128K,256K,512K,1MB
+
+Virtual Port ID:  0
+VLAN ID:  Disabled
+IP Address:  192.168.4.52
+Subnet Mask:  255.255.255.0
+Gateway Address:  0.0.0.0


### PR DESCRIPTION
This commit add __hash__ for VNXConnectionVirtualPort so that
it can be compared with VNXHbaPort.

This issue causes duplicate port registration in VNX Cinder driver.