### PR TITLE
Fix osp_deploy script

### DIFF
--- a/utility/osp_deploy.sh
+++ b/utility/osp_deploy.sh
@@ -1,52 +1,82 @@
 #! /usr/bin/bash
 
-# run as: osp_deploy.sh [arg1]
-# arg1 could be: (check in order)
-# 1. a local rpm file path.
-# 2. a specified release version on github.
-# 3. the latest version on github when arg1 is omitted.
+# run as: osp_deploy.sh [arg1, arg2, ...]
+# args could be: (check in order)
+# 1. local rpm file paths.
+# example: osp_deploy.sh storops.rpm cachez.rpm
+# 2. a specified release version of storops on github. (latest version is used
+# when the args are omitted.
+# example: osp_deploy.sh 0.5.7
+# example: osp_deploy.sh
+# 3. support download rpm packages only, using `download`.
+# example: osp_deploy.sh download 0.5.7
 
 # run on the undercloud node
 # assumes the latest rhosp-director-images is installed and unpacked
 # assumes there is an overcloud-full.qcow file in the directory the script is
 # run in
 
-if [ ! -f overcloud-full.qcow2 ]; then
+[ -n "$1" -a "$1" == "download" ] && download=1 && shift
+
+if [ -z "${download}" -a ! -f overcloud-full.qcow2 ]; then
     echo "must be run in a directory containing overcloud-full.qcow2"
     exit 1
 fi
 
-# need these packages installed
-sudo yum install -y libguestfs-tools-c wget
-
 if [ -n "$1" -a -f "$1" ]; then
-    mkdir newpkgs
-    echo "using local rpm file: $1"
-    cp "$1" newpkgs/
+    mkdir -p newpkgs
+    echo "using local rpm files: $@"
+    cp $@ newpkgs/
 else
+    mkdir -p newpkgs
+    cd newpkgs
+
+    sudo yum install -y curl
+
     release='latest'
     [ -n "$1" ] && release="tags/r$1"
 
-    rel_info="$(curl -s https://api.github.com/repos/emc-openstack/storops/releases/$release)"
-    if [[ $rel_info == *"\"message\": \"Not Found\""* ]]; then
-        echo "invalid release."
-        exit 1
-    fi
+    git_repos="emc-openstack/storops/releases/${release} \
+               peter-wangxu/persist-queue/releases/tags/v0.2.3 \
+               jealous/cachez/releases/tags/r0.1.2 \
+               jealous/retryz/releases/tags/r0.1.9"
 
-    download_url=$(echo "$rel_info" | grep -oh "browser_download_url\": \".*\"" | cut -d' ' -f2 | cut -d'"' -f2)
-    echo "$download_url"
-    if [ -z "$download_url" ]; then
-        echo "no rpm url found."
-        exit 1
-    fi
+    wget_urls="http://cbs.centos.org/kojifiles/packages/python-bitmath/1.3.1/1.el7/noarch/python2-bitmath-1.3.1-1.el7.noarch.rpm \
+               https://github.com/emc-openstack/naviseccli/raw/master/NaviCLI-Linux-64-x86-en_US-7.33.9.1.55-1.x86_64.rpm"
 
-    mkdir newpkgs
-    cd newpkgs
-    echo "using rpm file: $download_url"
-    wget $download_url
+    for repo in ${git_repos}; do
+
+        rel_info="$(curl -s https://api.github.com/repos/${repo})"
+        if [[ ${rel_info} == *"\"message\": \"Not Found\""* ]]; then
+            echo "invalid release."
+            exit 1
+        fi
+
+        download_url=$(echo "${rel_info}" | grep -oh "browser_download_url\": \".*\"" | grep ".rpm" | cut -d' ' -f2 | cut -d'"' -f2)
+        if [ -z "${download_url}" ]; then
+            echo "no rpm url found."
+            exit 1
+        fi
+	
+        for url in ${download_url}; do
+            echo "downloading rpm from: ${url}"
+            curl -sSOL ${url}
+        done
+    done
+
+    for url in ${wget_urls}; do
+        echo "downloading rpm from: ${url}"
+        curl -sSOL ${url}
+    done
+
     cd ..
 fi
 
+[ -n "${download}" ] && exit 0
+
+# need these packages installed
+sudo yum install -y libguestfs-tools-c
+
 virt-copy-in -a overcloud-full.qcow2 newpkgs /root
-virt-customize -a overcloud-full.qcow2 --run-command "yum localinstall -y /root/newpkgs/*rpm" --run-command "rm -rf /root/newpkgs"
+virt-customize -a overcloud-full.qcow2 --run-command "yum localinstall -y /root/newpkgs/*.rpm" --run-command "rm -rf /root/newpkgs"
 

--- a/utility/rpm_publish/python-storops-vnx.spec
+++ b/utility/rpm_publish/python-storops-vnx.spec
@@ -7,7 +7,7 @@
 %global pypi_name storops
 
 Name:           python-%{pypi_name}-vnx
-Version:        0.5.5
+Version:        0.5.7
 Release:        1%{?dist}
 Summary:        Library for managing Unity/VNX systems.
 
@@ -70,6 +70,9 @@ Library for managing Unity/VNX systems. Please refer to https://github.com/emc-o
 
 
 %changelog
+* Thu Feb 1 2018 Ryan Liang <ryan.liang@dell.com> - 0.5.7-1
+- Release v0.5.7: https://github.com/emc-openstack/storops/releases/tag/r0.5.7
+
 * Fri Nov 17 2017 Ryan Liang <ryan.liang@dell.com> - 0.5.5-1
 - Release v0.5.5: https://github.com/emc-openstack/storops/releases/tag/r0.5.5
 

--- a/utility/rpm_publish/python-storops.spec
+++ b/utility/rpm_publish/python-storops.spec
@@ -8,7 +8,7 @@
 # %%global pre_release dev.1
 
 Name:           python-%{pypi_name}
-Version:        0.5.6
+Version:        0.5.7
 Release:        %{?pre_release:0.%{pre_release}}%{!?pre_release:1}%{?dist}
 Summary:        Library for managing Unity/VNX systems.
 
@@ -134,6 +134,9 @@ Library for managing Unity/VNX systems. Please refer to https://github.com/emc-o
 
 
 %changelog
+* Thu Feb 1 2018 Ryan Liang <ryan.liang@dell.com> - 0.5.7-1
+- Release v0.5.7: https://github.com/emc-openstack/storops/releases/tag/r0.5.7
+
 * Thu Dec 28 2017 Ryan Liang <ryan.liang@dell.com> - 0.5.6-0.dev.1
 - Release v0.5.6-dev.1: https://github.com/emc-openstack/storops/releases/tag/r0.5.6-dev.1
 


### PR DESCRIPTION
The osp_deploy.sh doesn't work to deploy the storops rpm packages.
The old storops rpm contained all dependencies in it. But the new one
strip its dependencies out.