### PR TITLE
Unity: pass in non-zero hlu when attaching

### DIFF
--- a/storops/unity/resource/lun.py
+++ b/storops/unity/resource/lun.py
@@ -262,8 +262,10 @@ class UnityLun(UnityResource):
             TCHelper.notify(self, ThinCloneActionEnum.TC_DELETE)
         return resp
 
-    def attach_to(self, host, access_mask=HostLUNAccessEnum.PRODUCTION):
+    def _attach_to(self, host, access_mask, hlu):
         host_access = [{'host': host, 'accessMask': access_mask}]
+        if hlu is not None:
+            host_access[0]['hlu'] = hlu
         # If this lun has been attached to other host, don't overwrite it.
         if self.host_access:
             host_access += [{'host': item.host,
@@ -276,6 +278,15 @@ class UnityLun(UnityResource):
                   self.get_id())
         TCHelper.notify(self, ThinCloneActionEnum.LUN_ATTACH)
         return resp
+
+    @version('<4.4.0')  # noqa
+    def attach_to(self, host, access_mask=HostLUNAccessEnum.PRODUCTION):
+        return self._attach_to(host, access_mask, None)
+
+    @version('>=4.4.0')  # noqa
+    def attach_to(self, host, access_mask=HostLUNAccessEnum.PRODUCTION,
+                  hlu=None):
+        return self._attach_to(host, access_mask, hlu)
 
     def detach_from(self, host):
         if self.host_access is None:

--- a/storops_test/unity/resource/test_lun.py
+++ b/storops_test/unity/resource/test_lun.py
@@ -181,6 +181,21 @@ class UnityLunTest(TestCase):
         assert_that(resp.is_ok(), equal_to(True))
 
     @patch_rest
+    def test_lun_attach_to_with_hlu(self):
+        host = UnityHost(_id="Host_1", cli=t_rest())
+        lun = UnityLun(_id='sv_6', cli=t_rest(version='4.4.0'))
+        resp = lun.attach_to(host, access_mask=HostLUNAccessEnum.BOTH,
+                             hlu=1655)
+        assert_that(resp.is_ok(), equal_to(True))
+
+    @patch_rest
+    def test_lun_attach_to_without_hlu(self):
+        host = UnityHost(_id="Host_1", cli=t_rest())
+        lun = UnityLun(_id='sv_7', cli=t_rest(version='4.4.0'))
+        resp = lun.attach_to(host, access_mask=HostLUNAccessEnum.BOTH)
+        assert_that(resp.is_ok(), equal_to(True))
+
+    @patch_rest
     def test_lun_detach_from_host(self):
         host = UnityHost(_id="Host_1", cli=t_rest())
         lun = UnityLun(_id='sv_16', cli=t_rest())

--- a/storops_test/unity/rest_data/lun/index.json
+++ b/storops_test/unity/rest_data/lun/index.json
@@ -29,6 +29,14 @@
       "response": "sv_5.json"
     },
     {
+      "url": "/api/instances/lun/sv_6?compact=True&fields=auSize,creationTime,currentNode,defaultNode,description,health,hostAccess,hostAccess.host.name,id,instanceId,ioLimitPolicy,isCompressionEnabled,isDataReductionEnabled,isReplicationDestination,isSnapSchedulePaused,isThinEnabled,lunGroupObjectId,metadataSize,metadataSizeAllocated,modificationTime,name,objectId,operationalStatus,perTierSizeUsed,pool,pool.isFASTCacheEnabled,pool.name,pool.raidType,sizeAllocated,sizeTotal,sizeUsed,smpBackendId,snapCount,snapSchedule,snapWwn,snapsSize,snapsSizeAllocated,storageResource,storageResource.type,tieringPolicy,type,wwn",
+      "response": "sv_6.json"
+    },
+    {
+      "url": "/api/instances/lun/sv_7?compact=True&fields=auSize,creationTime,currentNode,defaultNode,description,health,hostAccess,hostAccess.host.name,id,instanceId,ioLimitPolicy,isCompressionEnabled,isDataReductionEnabled,isReplicationDestination,isSnapSchedulePaused,isThinEnabled,lunGroupObjectId,metadataSize,metadataSizeAllocated,modificationTime,name,objectId,operationalStatus,perTierSizeUsed,pool,pool.isFASTCacheEnabled,pool.name,pool.raidType,sizeAllocated,sizeTotal,sizeUsed,smpBackendId,snapCount,snapSchedule,snapWwn,snapsSize,snapsSizeAllocated,storageResource,storageResource.type,tieringPolicy,type,wwn",
+      "response": "sv_7.json"
+    },
+    {
       "url": "/api/instances/lun/sv_3338?compact=True&fields=auSize,creationTime,currentNode,defaultNode,description,health,hostAccess,hostAccess.host.name,id,instanceId,ioLimitPolicy,isCompressionEnabled,isDataReductionEnabled,isReplicationDestination,isSnapSchedulePaused,isThinEnabled,lunGroupObjectId,metadataSize,metadataSizeAllocated,modificationTime,name,objectId,operationalStatus,perTierSizeUsed,pool,pool.isFASTCacheEnabled,pool.name,pool.raidType,sizeAllocated,sizeTotal,sizeUsed,smpBackendId,snapCount,snapSchedule,snapWwn,snapsSize,snapsSizeAllocated,storageResource,storageResource.type,tieringPolicy,type,wwn",
       "response": "sv_3338.json"
     },

--- a/storops_test/unity/rest_data/lun/sv_6.json
+++ b/storops_test/unity/rest_data/lun/sv_6.json
@@ -1,0 +1,61 @@
+{
+    "content": {
+        "id": "sv_6",
+        "operationalStatus": [
+            2
+        ],
+        "type": 2,
+        "tieringPolicy": 1,
+        "defaultNode": 1,
+        "currentNode": 1,
+        "auSize": 8192,
+        "instanceId": "root/emc:EMC_UEM_StorageVolumeLeaf%InstanceID=sv_6",
+        "creationTime": "2016-05-24T05:24:55.000Z",
+        "health": {
+            "value": 5,
+            "descriptionIds": [
+                "ALRT_VOL_OK"
+            ],
+            "descriptions": [
+                "The LUN is operating normally. No action is required."
+            ]
+        },
+        "name": "RestLun100",
+        "description": "Lun description",
+        "modificationTime": "2016-05-24T05:25:02.086Z",
+        "sizeTotal": 1073741824,
+        "sizeAllocated": 0,
+        "perTierSizeUsed": [
+            0,
+            0,
+            2952790016
+        ],
+        "isThinEnabled": true,
+        "wwn": "60:06:01:60:24:10:3E:00:A7:E5:43:57:C0:CE:10:18",
+        "isReplicationDestination": false,
+        "isSnapSchedulePaused": false,
+        "objectId": 42949674123,
+        "metadataSize": 3489660928,
+        "metadataSizeAllocated": 2684354560,
+        "snapWwn": "60:06:01:60:24:10:3E:00:AB:E5:43:57:AE:C6:38:02",
+        "snapsSize": 0,
+        "snapsSizeAllocated": 0,
+        "hostAccess": [
+            {
+                "accessMask": 3,
+                "instanceId": "root/emc:EMC_UEM_HostAccessLunAssocLeaf%InstanceID=544",
+                "host": {
+                    "id": "Host_1"
+                }
+            }
+        ],
+        "snapCount": 0,
+        "storageResource": {
+            "id": "sv_6"
+        },
+        "pool": {
+            "id": "pool_1"
+        },
+        "isThinClone": false
+    }
+}

--- a/storops_test/unity/rest_data/lun/sv_7.json
+++ b/storops_test/unity/rest_data/lun/sv_7.json
@@ -1,0 +1,61 @@
+{
+    "content": {
+        "id": "sv_7",
+        "operationalStatus": [
+            2
+        ],
+        "type": 2,
+        "tieringPolicy": 1,
+        "defaultNode": 1,
+        "currentNode": 1,
+        "auSize": 8192,
+        "instanceId": "root/emc:EMC_UEM_StorageVolumeLeaf%InstanceID=sv_7",
+        "creationTime": "2016-05-24T05:24:55.000Z",
+        "health": {
+            "value": 5,
+            "descriptionIds": [
+                "ALRT_VOL_OK"
+            ],
+            "descriptions": [
+                "The LUN is operating normally. No action is required."
+            ]
+        },
+        "name": "RestLun100",
+        "description": "Lun description",
+        "modificationTime": "2016-05-24T05:25:02.086Z",
+        "sizeTotal": 1073741824,
+        "sizeAllocated": 0,
+        "perTierSizeUsed": [
+            0,
+            0,
+            2952790016
+        ],
+        "isThinEnabled": true,
+        "wwn": "60:06:01:60:24:10:3E:00:A7:E5:43:57:C0:CE:10:18",
+        "isReplicationDestination": false,
+        "isSnapSchedulePaused": false,
+        "objectId": 42949674123,
+        "metadataSize": 3489660928,
+        "metadataSizeAllocated": 2684354560,
+        "snapWwn": "60:06:01:60:24:10:3E:00:AB:E5:43:57:AE:C6:38:02",
+        "snapsSize": 0,
+        "snapsSizeAllocated": 0,
+        "hostAccess": [
+            {
+                "accessMask": 3,
+                "instanceId": "root/emc:EMC_UEM_HostAccessLunAssocLeaf%InstanceID=544",
+                "host": {
+                    "id": "Host_1"
+                }
+            }
+        ],
+        "snapCount": 0,
+        "storageResource": {
+            "id": "sv_7"
+        },
+        "pool": {
+            "id": "pool_1"
+        },
+        "isThinClone": false
+    }
+}

--- a/storops_test/unity/rest_data/storageResource/index.json
+++ b/storops_test/unity/rest_data/storageResource/index.json
@@ -89,6 +89,14 @@
       "response": "sv_5605.json"
     },
     {
+      "url": "/api/instances/storageResource/sv_6?compact=True&fields=blockHostAccess,datastores,dedupStatus,description,esxFilesystemBlockSize,esxFilesystemMajorVersion,filesystem,health,hostVVolDatastore,id,isReplicationDestination,isSnapSchedulePaused,luns,metadataSize,metadataSizeAllocated,name,perTierSizeUsed,pools,relocationPolicy,replicationType,sizeAllocated,sizeTotal,sizeUsed,snapCount,snapSchedule,snapsSizeAllocated,snapsSizeTotal,thinStatus,type,virtualVolumes,vmwareUUID",
+      "response": "sv_6.json"
+    },
+    {
+      "url": "/api/instances/storageResource/sv_7?compact=True&fields=blockHostAccess,datastores,dedupStatus,description,esxFilesystemBlockSize,esxFilesystemMajorVersion,filesystem,health,hostVVolDatastore,id,isReplicationDestination,isSnapSchedulePaused,luns,metadataSize,metadataSizeAllocated,name,perTierSizeUsed,pools,relocationPolicy,replicationType,sizeAllocated,sizeTotal,sizeUsed,snapCount,snapSchedule,snapsSizeAllocated,snapsSizeTotal,thinStatus,type,virtualVolumes,vmwareUUID",
+      "response": "sv_7.json"
+    },
+    {
       "url": "/api/instances/storageResource/res_23/action/modifyFilesystem?compact=True",
       "body": {
         "cifsShareCreate": [
@@ -579,6 +587,39 @@
         },
         "description": "Lun description",
         "name": "RestLun100"
+      },
+      "response": "empty.json"
+    },
+    {
+      "url": "/api/instances/storageResource/sv_6/action/modifyLun?compact=True",
+      "body": {
+        "lunParameters": {
+          "hostAccess": [
+            {
+              "host": {
+                "id": "Host_1"
+              },
+              "accessMask": 3,
+              "hlu": 1655
+            }
+          ]
+        }
+      },
+      "response": "empty.json"
+    },
+    {
+      "url": "/api/instances/storageResource/sv_7/action/modifyLun?compact=True",
+      "body": {
+        "lunParameters": {
+          "hostAccess": [
+            {
+              "host": {
+                "id": "Host_1"
+              },
+              "accessMask": 3
+            }
+          ]
+        }
       },
       "response": "empty.json"
     },

--- a/storops_test/unity/rest_data/storageResource/sv_6.json
+++ b/storops_test/unity/rest_data/storageResource/sv_6.json
@@ -1,0 +1,44 @@
+{
+  "content": {
+    "id": "sv_6",
+    "type": 8,
+    "replicationType": 0,
+    "thinStatus": 1,
+    "dedupStatus": 0,
+    "relocationPolicy": 0,
+    "health": {
+      "value": 5,
+      "descriptionIds": [
+        "ALRT_VOL_OK"
+      ],
+      "descriptions": [
+        "The LUN is operating normally. No action is required."
+      ]
+    },
+    "name": "openstack_lun",
+    "description": "",
+    "isReplicationDestination": false,
+    "sizeTotal": 107374182400,
+    "sizeAllocated": 0,
+    "perTierSizeUsed": [
+      2952790016,
+      0,
+      0
+    ],
+    "metadataSize": 5100273664,
+    "metadataSizeAllocated": 2684354560,
+    "snapsSizeTotal": 0,
+    "snapsSizeAllocated": 0,
+    "snapCount": 0,
+    "pools": [
+      {
+        "id": "pool_1"
+      }
+    ],
+    "luns": [
+      {
+        "id": "sv_6"
+      }
+    ]
+  }
+}

--- a/storops_test/unity/rest_data/storageResource/sv_7.json
+++ b/storops_test/unity/rest_data/storageResource/sv_7.json
@@ -1,0 +1,44 @@
+{
+  "content": {
+    "id": "sv_7",
+    "type": 8,
+    "replicationType": 0,
+    "thinStatus": 1,
+    "dedupStatus": 0,
+    "relocationPolicy": 0,
+    "health": {
+      "value": 5,
+      "descriptionIds": [
+        "ALRT_VOL_OK"
+      ],
+      "descriptions": [
+        "The LUN is operating normally. No action is required."
+      ]
+    },
+    "name": "openstack_lun",
+    "description": "",
+    "isReplicationDestination": false,
+    "sizeTotal": 107374182400,
+    "sizeAllocated": 0,
+    "perTierSizeUsed": [
+      2952790016,
+      0,
+      0
+    ],
+    "metadataSize": 5100273664,
+    "metadataSizeAllocated": 2684354560,
+    "snapsSizeTotal": 0,
+    "snapsSizeAllocated": 0,
+    "snapCount": 0,
+    "pools": [
+      {
+        "id": "pool_1"
+      }
+    ],
+    "luns": [
+      {
+        "id": "sv_7"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
From Osprey, it supports to pass in hlu when attaching lun to host. So
storops will randomize a non-zero hlu and pass it to attach action,
which could save the `modifyHostLUN` request.