### PR TITLE
[205]Fix issue for allowing snap host access.

### DIFF
--- a/storops_test/unity/resource/test_snap.py
+++ b/storops_test/unity/resource/test_snap.py
@@ -152,6 +152,13 @@ class UnitySnapTest(TestCase):
         assert_that(resp.is_ok(), equal_to(True))
 
     @patch_rest
+    def test_attach_second_snap_success(self):
+        snap = UnitySnap(_id='38654705670', cli=t_rest())
+        host = UnityHost(_id="Host_19", cli=t_rest())
+        resp = snap.attach_to(host)
+        assert_that(resp.is_ok(), equal_to(True))
+
+    @patch_rest
     def test_detach_snap_success(self):
         snap = UnitySnap(_id='38654705676', cli=t_rest())
         host = UnityHost(_id="Host_12", cli=t_rest())

--- a/storops_test/unity/rest_data/snap/38654705670.json
+++ b/storops_test/unity/rest_data/snap/38654705670.json
@@ -1,0 +1,35 @@
+{
+  "content": {
+    "creatorUser": {
+      "id": "user_admin"
+    },
+    "name": "snap1",
+    "creationTime": "2016-05-20T09:46:28.244Z",
+    "isModified": false,
+    "creatorType": 2,
+    "state": 2,
+    "size": 3221225472,
+    "storageResource": {
+      "id": "res_55"
+    },
+    "isReadOnly": false,
+    "description": "",
+    "accessType": 2,
+    "isModifiable": false,
+    "operationalStatus": [
+      9
+    ],
+    "instanceId": "root/emc:EMC_UEM_FilesystemSnapLeaf%InstanceID=38654705670",
+    "id": "38654705670",
+    "isSystemSnap": false,
+    "isAutoDelete": true,
+    "hostAccess": [
+      {
+        "allowedAccess": 0,
+        "host": {
+          "id": "Host_12"
+        }
+      }
+    ]
+  }
+}

--- a/storops_test/unity/rest_data/snap/index.json
+++ b/storops_test/unity/rest_data/snap/index.json
@@ -93,6 +93,10 @@
       "response": "38654709077.json"
     },
     {
+      "url": "/api/instances/snap/38654705670?compact=True&fields=accessType,attachedWWN,creationTime,creatorSchedule,creatorType,creatorUser,description,expirationTime,id,instanceId,ioLimitPolicy,isAutoDelete,isModifiable,isModified,isReadOnly,isSystemSnap,lastWritableTime,lun,name,operationalStatus,parentSnap,size,snapGroup,state,storageResource",
+      "response": "38654705670.json"
+    },
+    {
       "url": "/api/types/snap/instances?compact=True",
       "body": {
         "storageResource": {
@@ -238,6 +242,27 @@
       },
       "response": "snap_already_promoted.json"
     },
+    {
+      "url": "/api/instances/snap/38654705670/action/modify?compact=True",
+      "body": {
+        "hostAccess": [
+          {
+            "host": {
+              "id": "Host_19"
+            },
+            "allowedAccess": 1
+          },
+          {
+            "host": {
+              "id": "Host_12"
+            },
+            "allowedAccess": 0
+          }
+        ]
+      },
+      "response": "success.json"
+    },
+
     {
       "url": "/api/instances/snap/38654705676/action/attach?compact=True",
       "body": {


### PR DESCRIPTION
When attach an exported snapshot to another host, a error:

storops.exception.UnitySnapAlreadyPromotedException: The system was not
able to promote a snapshot because it is already promoted. (Error
Code:0x6000bdc)

will be throw. this commit will fix it by using the modify action