### PR TITLE
[GH-201]Add new HostTypeEnum

### DIFF
--- a/storops/unity/enums.py
+++ b/storops/unity/enums.py
@@ -98,6 +98,8 @@ class NasServerUnixDirectoryServiceEnum(UnityEnum):
     NONE = (0, 'No Directory Service')
     NIS = (2, 'Use NIS Server')
     LDAP = (3, 'Use LDAP Server')
+    LOCAL_THEN_NIS = (4, 'Local Then NIS')
+    LOCAL_THEN_LDAP = (5, 'Local Then LDAP')
 
 
 class FilesystemTypeEnum(UnityEnum):
@@ -206,6 +208,7 @@ class SnapCreatorTypeEnum(UnityEnum):
     EXTERNAL_REPLICATION_MANAGER = (8, 'Created by Replication Manger')
     REP_V2 = (9, 'Created by Native Replication')
     INBAND = (11, 'Created by SnapCLI')
+    APP_SYNC = (12, 'Created by AppSync')
 
 
 class SnapStateEnum(UnityEnum):
@@ -220,6 +223,9 @@ class SnapStateEnum(UnityEnum):
 class SnapAccessLevelEnum(UnityEnum):
     READ_ONLY = (0, 'Read Only')
     READ_WRITE = (1, 'Read Write')
+    READ_ONLY_PARTIAL = (2, 'Read Only Partial')
+    READ_WRITE_PARTIAL = (3, 'Read Write Partial')
+    MIXED = (4, 'Mixed')
 
 
 class FilesystemSnapAccessTypeEnum(UnityEnum):
@@ -285,7 +291,7 @@ class PoolUnitTypeEnum(UnityEnum):
     VIRTUAL_DISK = (2, 'Virtual Disk')
 
 
-class PoolTypeEnum(UnityEnum):
+class StoragePoolTypeEnum(UnityEnum):
     DYNAMIC = (1, 'Dynamic')
     TRADITIONAL = (2, 'Traditional')
 
@@ -313,6 +319,7 @@ class EnclosureTypeEnum(UnityEnum):
     RAMHORN_6G_SAS_DPE = (28, '25 Drive 6G DPE')
     TABASCO_12G_SAS_DAE = (29, '25 Drive 12G DAE')
     ANCHO_12G_SAS_DAE = (30, '15 Drive 12G DAE')
+    NAGA_12G_SAS_DAE = (32, '80 Drive 12G DAE')
     MIRANDA_12G_SAS_DPE = (36, '25 Drive 12G DPE')
     RHEA_12G_SAS_DPE = (37, '12 Drive 12G DPE')
     VIRTUAL_DPE = (100, 'Virtual DPE')
@@ -356,6 +363,7 @@ class DedupStatusEnum(UnityEnum):
 class ESXFilesystemMajorVersionEnum(UnityEnum):
     VMFS_3 = (3, 'VMFS 3')
     VMFS_5 = (5, 'VMFS 5')
+    VMFS_6 = (6, 'VMFS 6')
 
 
 class ESXFilesystemBlockSizeEnum(UnityEnum):
@@ -394,6 +402,7 @@ class HostTypeEnum(UnityEnum):
     NET_GROUP = (3, 'Net Group')
     RPA = (4, 'RecoverPoint Appliance')
     HOST_AUTO = (5, 'Auto-managed Host')
+    VNX_SAN_COPY = (255, 'VNX Block Migration system')
 
 
 class HostManageEnum(UnityEnum):
@@ -450,6 +459,7 @@ class DatastoreTypeEnum(UnityEnum):
     UNKNOWN = (0, 'Unknown')
     VMFS_3 = (1, 'VMFS 3')
     VMFS_5 = (2, 'VMFS 5')
+    VMFS_6 = (3, 'VMFS 6')
 
 
 class VMDiskTypeEnum(UnityEnum):
@@ -667,6 +677,8 @@ class JobTaskStateEnum(UnityEnum):
     COMPLETED = (2, 'Completed')
     FAILED = (3, 'Failed')
     ROLLING_BACK = (5, 'Rolling Back')
+    COMPLETED_WITH_PROBLEMS = (6, 'Completed With Errors')
+    SUSPENDED = (7, 'Suspended')
 
 
 class SeverityEnum(UnityEnum):
@@ -727,6 +739,7 @@ class DiskTechnologyEnum(UnityEnum):
     SAS_FLASH_2 = (6, 'SAS_FLASH_2')
     SAS_FLASH_3 = (7, 'SAS_FLASH_3')
     SAS_FLASH_4 = (8, 'SAS_FLASH_4')
+    SAS_FLASH_5 = (9, 'SAS_FLASH_5')
     MIXED = (50, 'Mixed')
     VIRTUAL = (99, 'Virtual')
 

--- a/storops/unity/parser_configs.yaml
+++ b/storops/unity/parser_configs.yaml
@@ -197,7 +197,7 @@ UnityPool:
     - label: rebalanceProgress
     - label: type
       key: pool_type
-      converter: PoolTypeEnum
+      converter: StoragePoolTypeEnum
     - label: isAllFlash
 
 

--- a/storops/unity/resource/system.py
+++ b/storops/unity/resource/system.py
@@ -145,8 +145,8 @@ class UnitySystem(UnitySingletonResource):
                True - Enable scheduled data relocations for the pool.
                False - Disable scheduled data relocations for the pool.
         :param pool_type:
-               PoolTypeEnum.TRADITIONAL - Create traditional pool.
-               PoolTypeEnum.DYNAMIC - Create dynamic pool. (default)
+               StoragePoolTypeEnum.TRADITIONAL - Create traditional pool.
+               StoragePoolTypeEnum.DYNAMIC - Create dynamic pool. (default)
         """
         return UnityPool.create(self._cli, name=name, description=description,
                                 raid_groups=raid_groups, **kwargs)

--- a/storops_test/unity/resource/test_pool.py
+++ b/storops_test/unity/resource/test_pool.py
@@ -25,7 +25,7 @@ from storops.unity.enums import RaidTypeEnum, FastVPStatusEnum, \
     FastVPRelocationRateEnum, PoolDataRelocationTypeEnum, \
     RaidStripeWidthEnum, TierTypeEnum, PoolUnitTypeEnum, \
     FSSupportedProtocolEnum, TieringPolicyEnum, JobStateEnum, \
-    PoolTypeEnum
+    StoragePoolTypeEnum
 from storops.unity.resource.disk import UnityDiskGroup, UnityDisk
 from storops.unity.resource.pool import UnityPool, UnityPoolList, \
     RaidGroupParameter
@@ -70,7 +70,7 @@ class UnityPoolTest(TestCase):
         assert_that(pool.metadata_size_used, equal_to(36775657472))
         assert_that(pool.snap_size_used, equal_to(24452407296))
         assert_that(pool.is_all_flash, equal_to(False))
-        assert_that(pool.pool_type, equal_to(PoolTypeEnum.TRADITIONAL))
+        assert_that(pool.pool_type, equal_to(StoragePoolTypeEnum.TRADITIONAL))
         tiers = pool.tiers
 
         assert_that(len(tiers), equal_to(3))
@@ -175,9 +175,9 @@ class UnityPoolTest(TestCase):
             pool_harvest_high_threshold=80, pool_harvest_low_threshold=40,
             snap_harvest_high_threshold=80, snap_harvest_low_threshold=40,
             is_fast_cache_enabled=True, is_fastvp_enabled=True,
-            pool_type=PoolTypeEnum.DYNAMIC)
+            pool_type=StoragePoolTypeEnum.DYNAMIC)
         assert_that(pool.id, equal_to('pool_4'))
-        assert_that(pool.pool_type, equal_to(PoolTypeEnum.DYNAMIC))
+        assert_that(pool.pool_type, equal_to(StoragePoolTypeEnum.DYNAMIC))
         assert_that(pool.is_all_flash, equal_to(False))
 
     @patch_rest

--- a/storops_test/unity/resource/test_system.py
+++ b/storops_test/unity/resource/test_system.py
@@ -28,7 +28,7 @@ from storops.lib.resource import ResourceList
 from storops.unity.enums import EnclosureTypeEnum, DiskTypeEnum, HealthEnum, \
     HostTypeEnum, ServiceLevelEnum, ServiceLevelEnumList, \
     StorageResourceTypeEnum, DNSServerOriginEnum, TierTypeEnum, \
-    RaidTypeEnum, RaidStripeWidthEnum, PoolTypeEnum, DiskTypeEnumList, \
+    RaidTypeEnum, RaidStripeWidthEnum, StoragePoolTypeEnum, DiskTypeEnumList, \
     SpeedValuesEnum, ConnectorTypeEnum, FeatureStateEnum, \
     InterfaceConfigModeEnum, IpProtocolVersionEnum
 from storops.unity.resource.cifs_server import UnityCifsServerList
@@ -272,7 +272,7 @@ class UnitySystemTest(TestCase):
             pool_harvest_high_threshold=80, pool_harvest_low_threshold=40,
             snap_harvest_high_threshold=80, snap_harvest_low_threshold=40,
             is_fast_cache_enabled=True, is_fastvp_enabled=True,
-            pool_type=PoolTypeEnum.DYNAMIC)
+            pool_type=StoragePoolTypeEnum.DYNAMIC)
         assert_that(pool, instance_of(UnityPool))
 
     @patch_rest


### PR DESCRIPTION
Here are the enums updated in this patch:

- Unity 4.1:
    * ConnectorTypeEnum
    * EnclosureTypeEnum
    * HostTypeEnum
    * IOLimitPolicyStateEnum
    * IOLimitPolicyTypeEnum
    * JobTaskStateEnum
    * MetricTypeEnum
    * NasServerUnixDirectoryServiceEnum
    * PoolTypeEnum
    * SnapAccessLevelEnum
    * SnapCreatorTypeEnum
- Unity 4.2:
    * DiskTechnologyEnum
    * DiskTypeEnum
- Unity 4.3:
    * DatastoreTypeEnum
    * ESXFilesystemMajorVersionEnum
