### PR TITLE
Allow comparison between HbaPort and VNXSPPort

### DIFF
--- a/storops/vnx/resource/port.py
+++ b/storops/vnx/resource/port.py
@@ -262,8 +262,11 @@ class VNXHbaPort(VNXPort):
                 'host_initiator_list']
 
     def __hash__(self):
-        return hash('<VNXPort {{sp: {}, port_id: {}, vport_id: {}}}'
-                    .format(self.sp, self.port_id, self.vport_id))
+        if self.vport_id is not None:
+            return hash('<VNXPort {{sp: {}, port_id: {}, vport_id: {}}}'
+                        .format(self.sp, self.port_id, self.vport_id))
+        else:
+            return super(VNXHbaPort, self).__hash__()
 
 
 class VNXConnectionPortList(VNXCliResourceList):

--- a/storops_test/vnx/resource/test_port.py
+++ b/storops_test/vnx/resource/test_port.py
@@ -522,6 +522,17 @@ class VNXPortTest(TestCase):
         assert_that(list(r)[0].sp, equal_to(VNXSPEnum.SP_B))
 
     @patch_cli
+    def test_hba_port_with_sp_port(self):
+        sg = VNXStorageGroup.get(cli=t_cli(), name='server7')
+        sg_ports = sg.get_ports(
+            '20:00:00:90:FA:53:4C:D0:10:00:00:90:FA:53:4C:D0')
+        sp_ports = VNXSPPort.get(cli=t_cli(), sp=VNXSPEnum.SP_A,
+                                 port_type=VNXPortType.FC)
+        r = set(sg_ports) - set(sp_ports)
+        for x in r:
+            assert_that(x.sp, equal_to(VNXSPEnum.SP_B))
+
+    @patch_cli
     def test_get_metrics_csv(self):
         ports = VNXSPPort.get(t_cli())
         csv = ports.get_metrics_csv()


### PR DESCRIPTION
The issue caused unnecessary FC port registration on storage group.
A lot of setpath commands were seen in cinder volume log:
```
Apr 20 04:54:17.296339 cdh2h14 cinder-volume[21900]: INFO storops.vnx.navi_command [req-e527001b-c1f8-4c46-a819-a4883eff439e req-497f227a-9226-4ab7-81e8-af35f6413af3 tempest-VolumesSnapshotTestJSON-1661562330 None] call command: /opt/Navisphere/bin/naviseccli -h 10.228.227.225 -user sysadmin -password *** -scope global storagegroup -setpath -gname cdh2h14 -hbauid 20:00:00:24:FF:5F:27:4C:21:00:00:24:FF:5F:27:4C -sp b -spport 2 -host cdh2h14 -o

```