### PR TITLE
Fixed parsing of mirror group async members

### DIFF
--- a/storops/lib/converter.py
+++ b/storops/lib/converter.py
@@ -379,3 +379,13 @@ def from_hour(hour_in_int):
     else:
         ret = None
     return ret
+
+
+def to_int_or_not_available(value_str):
+    ret = -1
+    if value_str:
+        try:
+            ret = int(value_str)
+        except:
+            pass
+    return ret

--- a/storops/lib/converter.py
+++ b/storops/lib/converter.py
@@ -379,4 +379,3 @@ def from_hour(hour_in_int):
     else:
         ret = None
     return ret
-    

--- a/storops/lib/converter.py
+++ b/storops/lib/converter.py
@@ -386,6 +386,6 @@ def to_int_or_not_available(value_str):
     if value_str:
         try:
             ret = int(value_str)
-        except:
+        except ValueError:
             pass
     return ret

--- a/storops/lib/converter.py
+++ b/storops/lib/converter.py
@@ -379,13 +379,4 @@ def from_hour(hour_in_int):
     else:
         ret = None
     return ret
-
-
-def to_int_or_not_available(value_str):
-    ret = -1
-    if value_str:
-        try:
-            ret = int(value_str)
-        except ValueError:
-            pass
-    return ret
+    

--- a/storops/vnx/parser_configs.yaml
+++ b/storops/vnx/parser_configs.yaml
@@ -743,9 +743,9 @@ VNXMirrorViewAsync:
       converter: to_int
     - label: "Update type:"
     - label: "Time in minutes since previous update:"
-      converter: to_int
+      converter: to_int_or_not_available
     - label: "Time in minutes until next update:"
-      converter: to_int
+      converter: to_int_or_not_available
     - label: "Last Image error:"
 
 VNXMirrorViewImageAsync:
@@ -786,6 +786,7 @@ VNXMirrorGroupAsync:
     - label: "Recovery Policy:"
       key: "group_mirrors"
       converter: VNXMirrorGroupMirrorAsyncList
+      end_pattern: ""
 
 VNXMirrorGroupMirrorAsync:
   data_src: cli

--- a/storops/vnx/parser_configs.yaml
+++ b/storops/vnx/parser_configs.yaml
@@ -743,9 +743,9 @@ VNXMirrorViewAsync:
       converter: to_int
     - label: "Update type:"
     - label: "Time in minutes since previous update:"
-      converter: to_int_or_not_available
+      converter: to_int
     - label: "Time in minutes until next update:"
-      converter: to_int_or_not_available
+      converter: to_int
     - label: "Last Image error:"
 
 VNXMirrorViewImageAsync:

--- a/storops_test/vnx/resource/test_mirror_view.py
+++ b/storops_test/vnx/resource/test_mirror_view.py
@@ -602,6 +602,7 @@ class VNXMirrorGroupAsyncTest(TestCase):
         assert_that(mg.role, equal_to('Primary'))
         assert_that(mg.condition, equal_to('Normal'))
         assert_that(mg.policy, equal_to(VNXMirrorGroupRecoveryPolicy.AUTO))
+        assert_that(len(mg.group_mirrors), equal_to(1))
 
     @patch_cli
     def test_get_all(self):


### PR DESCRIPTION
Before this commit members of a mirror group were not listed due to wrong parsing rules. 
Additionally there are some fields that have int value but occasionally the value can be "Not Available".
For this case the "Not Available" value is parsed as -1.