### PR TITLE
Unity: add thick lun support

### DIFF
--- a/storops/exception.py
+++ b/storops/exception.py
@@ -1310,5 +1310,10 @@ class UnityTCSnapUnderDestroyError(UnityThinCloneException):
     error_code = 108008719
 
 
-class UnityCGLunActionNotSupportError(UnityException):
-    message = 'The action not support on lun in cg. Execute it on cg object.'
+class UnityCGMemberActionNotSupportError(UnityException):
+    message = ('The action not support on lun in cg or member snap of cg snap.'
+               ' Execute it on cg level.')
+
+
+class UnityThinCloneNotAllowedError(UnityException):
+    message = 'Thinclone not support on thick luns or snaps of thick lun.'

--- a/storops/unity/resource/lun.py
+++ b/storops/unity/resource/lun.py
@@ -19,7 +19,8 @@ import logging
 
 import storops.unity.resource.pool
 from storops.exception import UnityBaseHasThinCloneError, \
-    UnityResourceNotFoundError, UnityCGLunActionNotSupportError
+    UnityResourceNotFoundError, UnityCGMemberActionNotSupportError, \
+    UnityThinCloneNotAllowedError
 from storops.lib.thinclone_helper import TCHelper
 from storops.lib.version import version
 from storops.unity.client import UnityClient
@@ -307,7 +308,7 @@ class UnityLun(UnityResource):
     def create_snap(self, name=None, description=None, is_auto_delete=None,
                     retention_duration=None):
         if self.is_cg_member:
-            raise UnityCGLunActionNotSupportError()
+            raise UnityCGMemberActionNotSupportError()
         return UnitySnap.create(self._cli, self.storage_resource,
                                 name=name, description=description,
                                 is_auto_delete=is_auto_delete,
@@ -317,7 +318,11 @@ class UnityLun(UnityResource):
     @version(">=4.2")
     def thin_clone(self, name, io_limit_policy=None, description=None):
         if self.is_cg_member:
-            raise UnityCGLunActionNotSupportError()
+            raise UnityCGMemberActionNotSupportError()
+
+        if not self.is_thin_enabled:
+            raise UnityThinCloneNotAllowedError()
+
         return TCHelper.thin_clone(self._cli, self, name, io_limit_policy,
                                    description)
 

--- a/storops/unity/resource/snap.py
+++ b/storops/unity/resource/snap.py
@@ -20,6 +20,8 @@ import logging
 import storops.unity.resource.cifs_share
 import storops.unity.resource.nfs_share
 import storops.unity.resource.storage_resource
+from storops.exception import UnityCGMemberActionNotSupportError, \
+    UnityThinCloneNotAllowedError
 from storops.lib.common import instance_cache
 from storops.lib.thinclone_helper import TCHelper
 from storops.lib.version import version
@@ -183,6 +185,12 @@ class UnitySnap(UnityResource):
         """Creates a new thin clone from this snapshot.
         .. note:: this snapshot should not enable Auto-Delete.
         """
+        if self.is_member_snap():
+            raise UnityCGMemberActionNotSupportError()
+
+        if self.lun and not self.lun.is_thin_enabled:
+            raise UnityThinCloneNotAllowedError()
+
         return TCHelper.thin_clone(self._cli, self, name, io_limit_policy,
                                    description)
 

--- a/storops_test/unity/resource/test_lun.py
+++ b/storops_test/unity/resource/test_lun.py
@@ -25,7 +25,8 @@ from storops import UnitySystem
 from storops.exception import UnitySnapNameInUseError, \
     UnityLunNameInUseError, UnityLunShrinkNotSupportedError, \
     UnityNothingToModifyError, UnityPerfMonNotEnabledError, \
-    UnityThinCloneLimitExceededError, UnityCGLunActionNotSupportError
+    UnityThinCloneLimitExceededError, UnityCGMemberActionNotSupportError, \
+    UnityThinCloneNotAllowedError
 from storops.unity.enums import HostLUNAccessEnum, NodeEnum, RaidTypeEnum
 from storops.unity.resource.disk import UnityDisk
 from storops.unity.resource.host import UnityBlockHostAccessList, UnityHost
@@ -379,10 +380,16 @@ class UnityLunEnablePerfStatsTest(TestCase):
     def test_create_snap_of_member_snap_not_support(self):
         lun = UnityLun(cli=t_rest(), _id='sv_58')
         assert_that(calling(lun.create_snap).with_args(name='not-support'),
-                    raises(UnityCGLunActionNotSupportError))
+                    raises(UnityCGMemberActionNotSupportError))
 
     @patch_rest
     def test_thinclone_of_member_snap_not_support(self):
         lun = UnityLun(cli=t_rest(version='4.3'), _id='sv_58')
         assert_that(calling(lun.thin_clone).with_args('not-support'),
-                    raises(UnityCGLunActionNotSupportError))
+                    raises(UnityCGMemberActionNotSupportError))
+
+    @patch_rest
+    def test_thinclone_of_thick_lun_not_allowed(self):
+        lun = UnityLun(cli=t_rest(version='4.3'), _id='sv_59')
+        assert_that(calling(lun.thin_clone).with_args('not-allowed'),
+                    raises(UnityThinCloneNotAllowedError))

--- a/storops_test/unity/rest_data/lun/index.json
+++ b/storops_test/unity/rest_data/lun/index.json
@@ -155,6 +155,10 @@
     {
       "url": "/api/instances/lun/sv_5612?compact=True&fields=auSize,creationTime,currentNode,defaultNode,description,health,hostAccess,hostAccess.host.name,id,instanceId,ioLimitPolicy,isReplicationDestination,isSnapSchedulePaused,isThinEnabled,lunGroupObjectId,metadataSize,metadataSizeAllocated,modificationTime,name,objectId,operationalStatus,perTierSizeUsed,pool,pool.isFASTCacheEnabled,pool.raidType,sizeAllocated,sizeTotal,sizeUsed,smpBackendId,snapCount,snapSchedule,snapWwn,snapsSize,snapsSizeAllocated,storageResource,storageResource.type,tieringPolicy,type,wwn",
       "response": "sv_5612.json"
+    },
+    {
+      "url": "/api/instances/lun/sv_59?compact=True&fields=auSize,creationTime,currentNode,defaultNode,description,health,hostAccess,hostAccess.host.name,id,instanceId,ioLimitPolicy,isReplicationDestination,isSnapSchedulePaused,isThinEnabled,lunGroupObjectId,metadataSize,metadataSizeAllocated,modificationTime,name,objectId,operationalStatus,perTierSizeUsed,pool,pool.isFASTCacheEnabled,pool.raidType,sizeAllocated,sizeTotal,sizeUsed,smpBackendId,snapCount,snapSchedule,snapWwn,snapsSize,snapsSizeAllocated,storageResource,storageResource.type,tieringPolicy,type,wwn",
+      "response": "sv_59.json"
     }
   ]
 }

--- a/storops_test/unity/rest_data/lun/sv_59.json
+++ b/storops_test/unity/rest_data/lun/sv_59.json
@@ -1,0 +1,54 @@
+{
+    "content": {
+        "id": "sv_59",
+        "operationalStatus": [
+            2
+        ],
+        "type": 2,
+        "tieringPolicy": 0,
+        "defaultNode": 1,
+        "currentNode": 1,
+        "auSize": 8192,
+        "instanceId": "root/emc:EMC_UEM_StorageVolumeLeaf%InstanceID=sv_59",
+        "creationTime": "2018-06-28T07:46:13.000Z",
+        "health": {
+            "value": 5,
+            "descriptionIds": [
+                "ALRT_VOL_OK"
+            ],
+            "descriptions": [
+                "The LUN is operating normally. No action is required."
+            ]
+        },
+        "name": "lun-liangr-1",
+        "description": "",
+        "modificationTime": "2018-06-28T07:46:15.168Z",
+        "sizeTotal": 5368709120,
+        "sizeAllocated": 5368709120,
+        "perTierSizeUsed": [
+            0,
+            8589934592,
+            0
+        ],
+        "isThinEnabled": false,
+        "wwn": "60:06:01:60:15:E0:3A:00:45:92:34:5B:00:2F:61:CE",
+        "isReplicationDestination": false,
+        "isSnapSchedulePaused": false,
+        "objectId": 42949673954,
+        "metadataSize": 3489660928,
+        "metadataSizeAllocated": 3221225472,
+        "snapWwn": "60:06:01:60:15:E0:3A:00:6C:D2:4A:67:8A:06:49:F6",
+        "snapsSize": 5373960192,
+        "snapsSizeAllocated": 0,
+        "snapCount": 1,
+        "storageResource": {
+            "id": "sv_59",
+            "type": 8
+        },
+        "pool": {
+            "id": "pool_2",
+            "raidType": 1,
+            "isFASTCacheEnabled": false
+        }
+    }
+}

--- a/storops_test/unity/rest_data/snap/38654705848.json
+++ b/storops_test/unity/rest_data/snap/38654705848.json
@@ -1,0 +1,24 @@
+{
+  "content": {
+    "id": "38654705848",
+    "creatorType": 6,
+    "state": 2,
+    "operationalStatus": [
+      2
+    ],
+    "instanceId": "root/emc:EMC_UEM_SnapGroupLeaf%InstanceID=85899345931",
+    "name": "2016-11-03_08.35.00",
+    "description": "",
+    "creationTime": "2016-11-03T08:35:00.521Z",
+    "isSystemSnap": false,
+    "isModifiable": false,
+    "isModified": false,
+    "isAutoDelete": true,
+    "storageResource": {
+      "id": "res_19"
+    },
+    "lun": {
+        "id": "sv_2"
+    }
+  }
+}

--- a/storops_test/unity/rest_data/snap/38654707273.json
+++ b/storops_test/unity/rest_data/snap/38654707273.json
@@ -1,0 +1,31 @@
+{
+    "content": {
+        "id": "38654707273",
+        "creatorType": 2,
+        "accessType": 1,
+        "state": 2,
+        "operationalStatus": [
+            2
+        ],
+        "instanceId": "root/emc:EMC_UEM_VolumeSnapLeaf%InstanceID=38654707273",
+        "name": "UTC_2018-06-29_03:03:06",
+        "description": "",
+        "creationTime": "2018-06-29T02:47:56.676Z",
+        "isSystemSnap": false,
+        "isModifiable": false,
+        "isReadOnly": true,
+        "isModified": false,
+        "isAutoDelete": true,
+        "size": 5368709120,
+        "storageResource": {
+            "id": "sv_59"
+        },
+        "lun": {
+            "id": "sv_59"
+        },
+        "creatorUser": {
+            "id": "user_admin"
+        }
+    }
+}
+

--- a/storops_test/unity/rest_data/snap/38654707282.json
+++ b/storops_test/unity/rest_data/snap/38654707282.json
@@ -1,0 +1,34 @@
+{
+    "content": {
+        "id": "38654707282",
+        "creatorType": 2,
+        "accessType": 1,
+        "state": 2,
+        "operationalStatus": [
+            2
+        ],
+        "instanceId": "root/emc:EMC_UEM_VolumeSnapLeaf%InstanceID=38654707282",
+        "name": "20180629055453.644+00-001",
+        "description": "",
+        "creationTime": "2018-06-29T05:54:53.643Z",
+        "isSystemSnap": false,
+        "isModifiable": false,
+        "isReadOnly": true,
+        "isModified": false,
+        "isAutoDelete": true,
+        "size": 1073741824,
+        "storageResource": {
+            "id": "res_36"
+        },
+        "lun": {
+            "id": "sv_974"
+        },
+        "snapGroup": {
+            "id": "85899345958"
+        },
+        "creatorUser": {
+            "id": "user_admin"
+        }
+    }
+}
+

--- a/storops_test/unity/rest_data/snap/index.json
+++ b/storops_test/unity/rest_data/snap/index.json
@@ -392,6 +392,18 @@
     {
       "url": "/api/types/snap/instances?compact=True&fields=accessType,attachedWWN,creationTime,creatorSchedule,creatorType,creatorUser,description,expirationTime,id,instanceId,ioLimitPolicy,isAutoDelete,isModifiable,isModified,isReadOnly,isSystemSnap,lastWritableTime,lun,name,operationalStatus,parentSnap,size,snapGroup,state,storageResource&filter=lun eq \"sv_58\" and snapGroup eq \"85899345958\"",
       "response": "filter_member_snap_sv_58.json"
+    },
+    {
+      "url": "/api/instances/snap/38654705848?compact=True&fields=accessType,attachedWWN,creationTime,creatorSchedule,creatorType,creatorUser,description,expirationTime,id,instanceId,ioLimitPolicy,isAutoDelete,isModifiable,isModified,isReadOnly,isSystemSnap,lastWritableTime,lun,name,operationalStatus,parentSnap,size,snapGroup,state,storageResource",
+      "response": "38654705848.json"
+    },
+    {
+      "url": "/api/instances/snap/38654707273?compact=True&fields=accessType,attachedWWN,creationTime,creatorSchedule,creatorType,creatorUser,description,expirationTime,id,instanceId,ioLimitPolicy,isAutoDelete,isModifiable,isModified,isReadOnly,isSystemSnap,lastWritableTime,lun,name,operationalStatus,parentSnap,size,snapGroup,state,storageResource",
+      "response": "38654707273.json"
+    },
+    {
+      "url": "/api/instances/snap/38654707282?compact=True&fields=accessType,attachedWWN,creationTime,creatorSchedule,creatorType,creatorUser,description,expirationTime,id,instanceId,ioLimitPolicy,isAutoDelete,isModifiable,isModified,isReadOnly,isSystemSnap,lastWritableTime,lun,name,operationalStatus,parentSnap,size,snapGroup,state,storageResource",
+      "response": "38654707282.json"
     }
   ]
 }

--- a/storops_test/unity/rest_data/storageResource/index.json
+++ b/storops_test/unity/rest_data/storageResource/index.json
@@ -1158,6 +1158,17 @@
       "url": "/api/instances/storageResource/res_21/action/modifyConsistencyGroup?compact=True",
       "body": {"lunRemove": [{"lun": {"id": "sv_59"}}], "lunAdd": [{"lun": {"id": "sv_60"}}]},
       "response": "empty.json"
+    },
+    {
+      "url": "/api/instances/storageResource/sv_2/action/createLunThinClone?compact=True",
+      "body": {
+        "name": "test_thin_clone",
+        "snap": {
+          "id": "38654705848"
+        },
+        "description": "This is description."
+      },
+      "response": "thin_clone_auto_delete.json"
     }
   ]
 }


### PR DESCRIPTION
Raise exceptions when thinclone thick luns or snaps of thick luns.