### PR TITLE
[GH-238] HLU number greater than 255

### DIFF
--- a/storops/unity/resource/host.py
+++ b/storops/unity/resource/host.py
@@ -63,7 +63,7 @@ class UnitySnapHostAccessList(UnityResourceList):
 
 
 DUMMY_LUN_NAME = 'storops_dummy_lun'
-MAX_HLU_NUMBER = 16381
+MAX_HLU_NUMBER = 255  # Unity supports 16381 but uses 255 here due to GH-238
 
 
 class UnityHost(UnityResource):


### PR DESCRIPTION
Unity supports maximum HLU number is 16381. So storops supports to
random pick a number from 0 to 16381 as the HLU when attaching the LUN
to host.

However, HLU number greater than 255 affects the operation of extending
an attached volume in OpenStack. The reason is that os-brick invokes
command `sg_scan` to get device information when extending volume, while
`sg_scan` uses 8 bits (maximum number is 255) to store the LUN id.
Any number greater than 255 will be truncated to wrong number via `and`
operation with `0xff`.

Thus, we need to update the range to [0 , 255].