### PR TITLE
VNX: persist queue cross device link error

### DIFF
--- a/storops/lib/tasks.py
+++ b/storops/lib/tasks.py
@@ -36,7 +36,7 @@ class PQueue(object):
 
     def __init__(self, path, interval=None):
         self.path = path
-        self._q = persistqueue.Queue(self.path)
+        self._q = persistqueue.Queue(self.path, tempdir=self.path)
         self._interval = (
             self.DEFAULT_INTERVAL if interval is None else interval)
         self.started = False


### PR DESCRIPTION
The bug was reported: https://bugs.launchpad.net/cinder/+bug/1796827.

Storops supports the configured path and uses persist-queue to persist
the data to that path. However, the persist-queue is implemented to
write the data to a temp path, then leverages the atomic `os.rename` to
store the data to the user specified path.

The problem occurs when the temp path and the user specified path are on
two different devices. It raises `OSError: Invalid cross-device link`.

The fix is to make sure the temp path is no the same device of the user
specified one.