### PR TITLE
[GH-246] requests 2.20.0 issue cause storops fails to connect Unity

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests!=2.9.0,>=2.8.1 # Apache-2.0, cinder, manila
+requests>=2.8.1,!=2.9.0,!=2.20.0 # Apache-2.0, cinder, manila
 PyYAML>=3.10 # MIT, cinder, manila
 six>=1.9.0 # MIT, cinder, manila
 enum34;python_version<'3.4' # BSD


### PR DESCRIPTION
In requests 2.20.0, when doing authorization, if the port of
redirect url is different from original url, the authorization
header will be dropped, already fixed and verified in latest
requests commit. So skip requests 2.20.0 in requirements.txt