### PR TITLE
[GH-248] Unity:raise error if service unavailable

### DIFF
--- a/storops/connection/client.py
+++ b/storops/connection/client.py
@@ -110,7 +110,11 @@ class HTTPClient(object):
             except ValueError:
                 pass
 
-        if resp.status_code == 401:
+        # The reason why not raise if `status_code` >= 400 is that we don't
+        # want to raise if code is 404 - Not Found. The upper layer will check
+        # the returned resource and raise `ResourceNotFoundError` or some thing
+        # like it.
+        if resp.status_code >= 400 and resp.status_code != 404:
             raise exceptions.from_response(resp, method, full_url)
 
         return resp, body


### PR DESCRIPTION
When the Unity service is unavailable, getting any resource would return
UnityResourceNotFoundError. This behavior is wrong. For example,
OpenStack checks the host existing or not before creating a new one.

Let's say the Host-1 already exists, and if the GET request is sent when
the service unavailable, the UnityResourceNotFoundError will cause
another host created with the same name.