### PR TITLE
[#248] Unity: retry not work

### DIFF
--- a/storops/connection/client.py
+++ b/storops/connection/client.py
@@ -110,11 +110,9 @@ class HTTPClient(object):
             except ValueError:
                 pass
 
-        # The reason why not raise if `status_code` >= 400 is that we don't
-        # want to raise if code is 404 - Not Found. The upper layer will check
-        # the returned resource and raise `ResourceNotFoundError` or some thing
-        # like it.
-        if resp.status_code >= 400 and resp.status_code != 404:
+        # These errors should be raised directly, do NOT retry any more,
+        # like 401 - unauthorized, 503 - service unavailable.
+        if resp.status_code in [401, 503]:
             raise exceptions.from_response(resp, method, full_url)
 
         return resp, body


### PR DESCRIPTION
Fix #249 to issue #248 is too open. It changed
`if resp.status_code == 401:` to
`if resp.status_code >= 400 and resp.status_code != 404:`, which means
status code like 422 (hlu number conflict) raise `HttpClientError` and
the `HttpClientError` cannot be caught afterward and exceptions to
Cinder. Thus the retry mechanism doesn't take effect.

Another example is that deleting a volume twice. The second would return
409, and `HttpClientError` is raised directly to Cinder. The expected
behavior should be that `ResourceNotFound` is caught and ignored by
Unity driver.