### PR TITLE
[Unity] Add exceptions for input shrink share size

### DIFF
--- a/storops/exception.py
+++ b/storops/exception.py
@@ -314,7 +314,11 @@ class UnityAttachError(UnityException):
     pass
 
 
-class UnityShareShrinkSizeError(StoropsException):
+class UnityShareShrinkSizeTooLargeError(StoropsException):
+    pass
+
+
+class UnityShareShrinkSizeTooSmallError(StoropsException):
     pass
 
 

--- a/storops/unity/resource/filesystem.py
+++ b/storops/unity/resource/filesystem.py
@@ -19,7 +19,8 @@ import logging
 
 from storops.lib.common import supplement_filesystem
 from storops.exception import UnityResourceNotFoundError, \
-    UnityCifsServiceNotEnabledError, UnityShareShrinkSizeError
+    UnityCifsServiceNotEnabledError, UnityShareShrinkSizeTooLargeError,\
+    UnityShareShrinkSizeTooSmallError
 from storops.unity.enums import FSSupportedProtocolEnum, TieringPolicyEnum, \
     SnapStateEnum
 
@@ -108,12 +109,17 @@ class UnityFileSystem(UnityResource):
     def shrink(self, new_size, user_cap=False):
         sr = self.storage_resource
         new_size = supplement_filesystem(new_size, user_cap)
+        size_used = sr.size_used
+        if size_used and int(size_used) > new_size:
+            message = 'Reject shrink share request, ' \
+                      'the new size should be larger than used.'
+            raise UnityShareShrinkSizeTooSmallError(message)
         param = self._cli.make_body(size=new_size)
         size_total = sr.size_total
         if size_total and int(size_total) < new_size:
             message = 'Reject shrink share request, ' \
                       'the new size should be smaller than original.'
-            raise UnityShareShrinkSizeError(message)
+            raise UnityShareShrinkSizeTooLargeError(message)
         resp = sr.modify_fs(fsParameters=param)
         resp.raise_if_err()
         return resp


### PR DESCRIPTION
Compare the below value before change the FS size:
used size ,
shrink size, 
current total size
