### PR TITLE
Remove exclusion of requests 2.22.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests>=2.8.1,!=2.9.0,!=2.20.0,!=2.22.0 # Apache-2.0, cinder, manila
+requests>=2.8.1,!=2.9.0,!=2.20.0 # Apache-2.0, cinder, manila
 PyYAML>=3.10 # MIT, cinder, manila
 six>=1.9.0 # MIT, cinder, manila
 enum34;python_version<'3.4' # BSD


### PR DESCRIPTION
Fixing #276. requests 2.22.0 is used by OpenStack.