### PR TITLE
Unity: add connect timeout exception

### DIFF
--- a/storops/connection/client.py
+++ b/storops/connection/client.py
@@ -27,6 +27,7 @@ from requests.exceptions import RequestException
 from retryz import retry
 
 from storops.connection import exceptions
+from storops.exception import StoropsConnectTimeoutError
 
 log = logging.getLogger(__name__)
 
@@ -118,10 +119,13 @@ class HTTPClient(object):
         return resp, body
 
     def _cs_request(self, url, method, **kwargs):
-        return self._cs_request_with_retries(
-            self.base_url + url,
-            method,
-            **kwargs)
+        try:
+            return self._cs_request_with_retries(
+                self.base_url + url,
+                method,
+                **kwargs)
+        except requests.ConnectTimeout as ex:
+            raise StoropsConnectTimeoutError(message=str(ex))
 
     def _get_limit(self):
         return self.retries

--- a/storops/connection/connector.py
+++ b/storops/connection/connector.py
@@ -54,7 +54,8 @@ class UnityRESTConnector(object):
     }
 
     def __init__(self, host, port=443, user='admin', password='',
-                 verify=False, retries=None, cache_interval=0):
+                 verify=False, retries=None, cache_interval=0,
+                 connect_timeout=30):
         base_url = 'https://{host}:{port}'.format(host=host, port=port)
 
         insecure = False
@@ -69,7 +70,8 @@ class UnityRESTConnector(object):
                                              insecure=insecure,
                                              retries=retries,
                                              ca_cert_path=ca_cert_path,
-                                             cache_interval=cache_interval)
+                                             cache_interval=cache_interval,
+                                             timeout=(connect_timeout, None))
 
     def get(self, url, **kwargs):
         return self.http_client.get(url, **kwargs)

--- a/storops/exception.py
+++ b/storops/exception.py
@@ -1389,3 +1389,7 @@ class UnityVNXSANCopyHostNotExistsError(UnityImportSessionException):
 @rest_exception
 class UnitySourceResourceInAnImportSessionError(UnityImportSessionException):
     error_code = 105906723
+
+
+class StoropsConnectTimeoutError(StoropsException):
+    pass

--- a/storops_test/connection/test_connector.py
+++ b/storops_test/connection/test_connector.py
@@ -38,7 +38,9 @@ class UnityRESTConnectorTest(unittest.TestCase):
             insecure=True,
             retries=None,
             ca_cert_path=None,
-            cache_interval=0)
+            cache_interval=0,
+            timeout=(30, None),
+        )
 
     @mock.patch('storops.connection.client.HTTPClient')
     def test_new_connector_verify_true(self, mocked_httpclient):
@@ -53,7 +55,9 @@ class UnityRESTConnectorTest(unittest.TestCase):
             insecure=False,
             retries=None,
             ca_cert_path=None,
-            cache_interval=0)
+            cache_interval=0,
+            timeout=(30, None),
+        )
 
     @mock.patch('storops.connection.client.HTTPClient')
     def test_new_connector_verify_path(self, mocked_httpclient):
@@ -68,4 +72,23 @@ class UnityRESTConnectorTest(unittest.TestCase):
             insecure=False,
             retries=None,
             ca_cert_path='/tmp/ca_cert.crt',
-            cache_interval=0)
+            cache_interval=0,
+            timeout=(30, None),
+        )
+
+    @mock.patch('storops.connection.client.HTTPClient')
+    def test_new_connector_connect_timeout(self, mocked_httpclient):
+
+        connector.UnityRESTConnector('10.10.10.10',
+                                     connect_timeout=99)
+
+        mocked_httpclient.assert_called_with(
+            base_url='https://10.10.10.10:443',
+            headers=connector.UnityRESTConnector.HEADERS,
+            auth=('admin', ''),
+            insecure=True,
+            retries=None,
+            ca_cert_path=None,
+            cache_interval=0,
+            timeout=(99, None),
+        )


### PR DESCRIPTION
Set the default connect timeout to 10 sec for `UnityRESTConnector`. And
raise `StoropsConnectTimeoutError` when timeout to connect to the server
using `HTTPClient`.