### PR TITLE
Unity: RO share has RW access right

### DIFF
--- a/storops/unity/resource/nfs_share.py
+++ b/storops/unity/resource/nfs_share.py
@@ -81,7 +81,6 @@ class UnityNfsHostConfig(object):
     def allow_ro(self, *hosts):
         self.delete_access(*hosts)
         self.ro = self._add(self.ro, hosts)
-        self.root = self._add(self.root, hosts)
         return self
 
     def allow_rw(self, *hosts):

--- a/storops_test/unity/rest_data/nfsShare/index.json
+++ b/storops_test/unity/rest_data/nfsShare/index.json
@@ -81,11 +81,6 @@
     {
       "url": "/api/instances/nfsShare/NFSShare_30/action/modify?compact=True",
       "body": {
-        "rootAccessHosts": [
-          {
-            "id": "Host_11"
-          }
-        ],
         "readOnlyHosts": [
           {
             "id": "Host_11"

--- a/storops_test/unity/rest_data/storageResource/index.json
+++ b/storops_test/unity/rest_data/storageResource/index.json
@@ -407,14 +407,6 @@
                   "id": "Host_7"
                 }
               ],
-              "rootAccessHosts": [
-                {
-                  "id": "Host_1"
-                },
-                {
-                  "id": "Host_11"
-                }
-              ],
               "readOnlyHosts": [
                 {
                   "id": "Host_1"
@@ -970,11 +962,6 @@
               "id": "NFSShare_32"
             },
             "nfsShareParameters": {
-              "rootAccessHosts": [
-                {
-                  "id": "Host_16"
-                }
-              ],
               "readOnlyHosts": [
                 {
                   "id": "Host_16"


### PR DESCRIPTION
The current implementation gives a RO and ROOT access level to the share
when allow RO access right. If the ROOT access level is given, the share
will be RW finally which is not expected.