### PR TITLE
[#264] PyYAML load warning

### DIFF
--- a/storops/lib/metric.py
+++ b/storops/lib/metric.py
@@ -18,6 +18,7 @@ from __future__ import unicode_literals
 import os
 
 import yaml
+from yaml import loader
 
 from storops.lib.common import RepeatedTimer, cache
 from storops.lib.resource import ResourceList
@@ -196,7 +197,7 @@ class MetricConfigParser(object):
     def _read_configs(cls):
         filename = os.path.join(cls.get_folder(), cls.config_filename)
         with open(filename, 'r') as stream:
-            ret = yaml.load(stream)
+            ret = yaml.load(stream, Loader=loader.SafeLoader)
         return ret
 
     @classmethod

--- a/storops/lib/parser.py
+++ b/storops/lib/parser.py
@@ -24,6 +24,7 @@ import re
 import six
 
 import yaml
+from yaml import loader
 
 from storops.lib.common import cache, instance_cache, Enum, \
     get_clz_from_module, EnumList
@@ -357,7 +358,7 @@ class ParserConfigFactory(object):
     def _read_configs(self):
         filename = os.path.join(self.get_folder(), self.config_filename)
         with open(filename, 'r') as stream:
-            ret = yaml.load(stream)
+            ret = yaml.load(stream, Loader=loader.SafeLoader)
         return ret
 
     @instance_cache


### PR DESCRIPTION
Use SafeLoader instead.
FullLoader (default loader) has exploit issue.
https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation