### PR TITLE
[#305] VNX: alu-hlu cache dirty

### DIFF
--- a/storops_test/vnx/resource/test_sg.py
+++ b/storops_test/vnx/resource/test_sg.py
@@ -95,11 +95,7 @@ def get_sg(name='server7'):
 
 
 class VNXStorageGroupTest(TestCase):
-    def setUp(self):
-        self.sg_7 = get_sg()
-
-    def tearDown(self):
-        self.sg_7 = None
+    sg_7 = get_sg()
 
     @patch_cli
     def test_properties(self):
@@ -260,8 +256,8 @@ class VNXStorageGroupTest(TestCase):
 
         assert_that(f, raises(VNXAluAlreadyAttachedError,
                               'already been added'))
-        assert_that(sg.get_hlu(123), equal_to(1))
-        assert_that(len(sg.get_alu_hlu_map()), equal_to(3))
+        assert_that(sg.get_hlu(123), none())
+        assert_that(len(sg.get_alu_hlu_map()), equal_to(2))
 
     @patch_cli
     def test_attach_alu_hlu_used(self):
@@ -346,18 +342,6 @@ class VNXStorageGroupTest(TestCase):
                               'is not attached'))
 
     @patch_cli
-    def test_cache_update_incremental(self):
-
-        sg = get_sg()
-        # Append an alu/hlu into the cache.
-        # make sure it's not flushed out by a sg.update call
-        sg._alu_hlu_cache.update({100: 200})
-        sg.update()
-        sg.attach_alu(2, retry_limit=2)
-        assert_that(sg.get_alu_hlu_map(),
-                    equal_to({100: 200, 1032: 210, 10: 153, 2: 1}))
-
-    @patch_cli
     def test_connect_host(self):
         def f():
             sg = self.sg_7
@@ -396,9 +380,7 @@ class VNXStorageGroupTest(TestCase):
 
     @patch_cli
     def test_get_hlu_to_add_no_shuffle(self):
-
         sg = get_sg()
-
         sg.shuffle_hlu = False
         assert_that(sg._get_hlu_to_add(12), equal_to(1))
         sg._delete_alu(12)


### PR DESCRIPTION
This commit first reverts "Fix alu/hlu cache issue (#181)",
the commit id is e82db793b73c224f6b8b0f6aa222d6f666846cec.

The root cause of #181 was `sg.update()` would flush the alu-hlu
mapping which was not returned by `sg.update()` but the LUN/alu was
attached successfully on VNX. VNX was slow, which caused the info
returnd by `sg.update()` was not the latest one.

To fix the issue of #181, a retry is added to `detach_alu`. That is,
when it found the alu-hlu is not in the cache, it will update sg's
alu-hlu-map and try to get the hlu again.