### PR TITLE
[#307] Unity: fix url encoding

### DIFF
--- a/storops/unity/client.py
+++ b/storops/unity/client.py
@@ -19,6 +19,7 @@ import logging
 from functools import wraps
 
 import six
+from six.moves import urllib
 
 import storops.unity.resource.system
 import storops.unity.resource.type_resource
@@ -87,7 +88,13 @@ class UnityClient(PerfManager):
     def dict_to_filter_string(cls, the_filter):
         def _get_non_list_value(k, v):
             if isinstance(v, six.string_types):
-                r = '{} eq "{}"'.format(k, v)
+                # Don't encode : and space chars, they are known working with
+                # Unity, eg. hostInitiator's initiatorID is string like
+                # iqn.1993-08.org.debian:01:a4f95ed19999 and sp name is `SP A`.
+                # And they are massively used in test cases.
+                # So, not to encode : and space to avoid introducing
+                # regression failure.
+                r = '{} eq "{}"'.format(k, urllib.parse.quote(v, safe=': '))
             elif isinstance(v, UnityEnum):
                 r = '{} eq {}'.format(k, v.value[0])
             elif isinstance(v, UnityResource):

--- a/storops_test/unity/resource/test_system.py
+++ b/storops_test/unity/resource/test_system.py
@@ -190,6 +190,20 @@ class UnitySystemTest(TestCase):
         assert_that(len(lun_list), equal_to(5))
 
     @patch_rest
+    def test_get_lun_by_name(self):
+        unity = t_unity()
+        lun = unity.get_lun(name='openstack_lun')
+        assert_that(lun, instance_of(UnityLun))
+        assert_that(lun.id, equal_to('sv_2'))
+
+    @patch_rest
+    def test_get_lun_by_name_need_encoded(self):
+        unity = t_unity()
+        lun = unity.get_lun(name='openstack_lun_#1')
+        assert_that(lun, instance_of(UnityLun))
+        assert_that(lun.id, equal_to('sv_2'))
+
+    @patch_rest
     def test_create_host(self):
         unity = t_unity()
         host = unity.create_host("Hello")

--- a/storops_test/unity/rest_data/lun/index.json
+++ b/storops_test/unity/rest_data/lun/index.json
@@ -48,8 +48,12 @@
       "url": "/api/types/lun/instances?compact=True&fields=auSize,creationTime,currentNode,defaultNode,description,health,hostAccess,hostAccess.host.name,id,instanceId,ioLimitPolicy,isCompressionEnabled,isDataReductionEnabled,isReplicationDestination,isSnapSchedulePaused,isThinEnabled,lunGroupObjectId,metadataSize,metadataSizeAllocated,modificationTime,name,objectId,operationalStatus,perTierSizeUsed,pool,pool.isFASTCacheEnabled,pool.name,pool.raidType,sizeAllocated,sizeTotal,sizeUsed,smpBackendId,snapCount,snapSchedule,snapWwn,snapsSize,snapsSizeAllocated,storageResource,storageResource.type,tieringPolicy,type,wwn",
       "response": "all.json"
     },
-      {
+    {
       "url": "/api/types/lun/instances?compact=True&fields=auSize,creationTime,currentNode,defaultNode,description,health,hostAccess,hostAccess.host.name,id,instanceId,ioLimitPolicy,isCompressionEnabled,isDataReductionEnabled,isReplicationDestination,isSnapSchedulePaused,isThinEnabled,lunGroupObjectId,metadataSize,metadataSizeAllocated,modificationTime,name,objectId,operationalStatus,perTierSizeUsed,pool,pool.isFASTCacheEnabled,pool.name,pool.raidType,sizeAllocated,sizeTotal,sizeUsed,smpBackendId,snapCount,snapSchedule,snapWwn,snapsSize,snapsSizeAllocated,storageResource,storageResource.type,tieringPolicy,type,wwn&filter=name eq \"openstack_lun\"",
+      "response": "sv_2.json"
+    },
+    {
+      "url": "/api/types/lun/instances?compact=True&fields=auSize,creationTime,currentNode,defaultNode,description,health,hostAccess,hostAccess.host.name,id,instanceId,ioLimitPolicy,isCompressionEnabled,isDataReductionEnabled,isReplicationDestination,isSnapSchedulePaused,isThinEnabled,lunGroupObjectId,metadataSize,metadataSizeAllocated,modificationTime,name,objectId,operationalStatus,perTierSizeUsed,pool,pool.isFASTCacheEnabled,pool.name,pool.raidType,sizeAllocated,sizeTotal,sizeUsed,smpBackendId,snapCount,snapSchedule,snapWwn,snapsSize,snapsSizeAllocated,storageResource,storageResource.type,tieringPolicy,type,wwn&filter=name eq \"openstack_lun_%231\"",
       "response": "sv_2.json"
     },
     {


### PR DESCRIPTION
The filter doesn't work when having \# char in name. Need to encode it
before sending to Unity.

Use a general function `urllib.parse.quote` to encode all chars except
: and space. : and space chars are known working with Unity,
eg. hostInitiator's initiatorID is string like
iqn.1993-08.org.debian:01:a4f95ed19999 and sp name is `SP A`.
And they are massively used in test cases. So, not to encode them to
avoid introducing regression failure.