### PR TITLE
Fix flask8 variable name errors

### DIFF
--- a/storops/lib/resource.py
+++ b/storops/lib/resource.py
@@ -218,7 +218,7 @@ class ResourceList(Resource):
 
     @classmethod
     def get_rsc_clz_list(cls, rsc_list_collection):
-        return [l.get_resource_class() for l in rsc_list_collection]
+        return [lst.get_resource_class() for lst in rsc_list_collection]
 
     @clear_instance_cache
     def update(self, data=None):

--- a/storops/unity/resource/nfs_share.py
+++ b/storops/unity/resource/nfs_share.py
@@ -68,9 +68,9 @@ class UnityNfsHostConfig(object):
             ret = left
         else:
             ret = []
-            for l in left:
-                if l not in right:
-                    ret.append(l)
+            for lft in left:
+                if lft not in right:
+                    ret.append(lft)
         return ret
 
     def allow_root(self, *hosts):


### PR DESCRIPTION
Variable cannot be named as `l`.