### PR TITLE
[#305] VNX: add shared cache for sg

### DIFF
--- a/storops/__init__.py
+++ b/storops/__init__.py
@@ -24,6 +24,7 @@ from storops.unity.resource.system import UnitySystem  # noqa
 from storops.unity.resource.snap_schedule import UnitySnapScheduleRule  # noqa
 from storops.vnx.enums import *  # noqa
 from storops.vnx.resource.system import VNXSystem  # noqa
+from storops.vnx.sg_cache import SGCache  # noqa
 
 __author__ = 'Cedric Zhuang'
 

--- a/storops/vnx/enums.py
+++ b/storops/vnx/enums.py
@@ -87,6 +87,10 @@ class VNXSPEnum(VNXEnum):
     def display_name(self):
         return self.index.upper()
 
+    # `__reduce_ex__` makes `VNXSPEnum` pickable by value.
+    def __reduce_ex__(self, protocol):
+        return self.__class__, (self.value,)
+
 
 class VNXProvisionEnum(VNXEnum):
     # value of spec "provisioning:type"

--- a/storops/vnx/heart_beat.py
+++ b/storops/vnx/heart_beat.py
@@ -306,3 +306,16 @@ class NodeHeartBeat(NaviCommand):
 
     def __str__(self):
         return self.__repr__()
+
+    # `__getstate__` and `__setstate__` are used by Pickle.
+    # Because `_heartbeat_thread` is unpicklable, need to construct it
+    # manually.
+    def __getstate__(self):
+        state = vars(self).copy()
+        del state['_heartbeat_thread']
+        return state
+
+    def __setstate__(self, state):
+        vars(self).update(state)
+        if self.interval > 0:
+            self._heartbeat_thread = daemon(self._run)

--- a/storops/vnx/resource/port.py
+++ b/storops/vnx/resource/port.py
@@ -521,3 +521,10 @@ class VNXStorageGroupHBAList(VNXCliResourceList):
     @classmethod
     def get_resource_class(cls):
         return VNXStorageGroupHBA
+
+    # `__getstate__` and `__setstate__` are used by Pickle.
+    def __getstate__(self):
+        return vars(self)
+
+    def __setstate__(self, state):
+        vars(self).update(state)

--- a/storops/vnx/resource/sg.py
+++ b/storops/vnx/resource/sg.py
@@ -378,6 +378,21 @@ class VNXStorageGroup(VNXCliResource):
     def set_system_lun_list(self, system_lun_list):
         self._system_lun_list = system_lun_list
 
+    # `__getstate__` and `__setstate__` are used by Pickle.
+    # Because `_hlu_lock` is unpicklable, need to construct it manually.
+    # `_self_cache_lock_` is used by `cachez` and will be constructed
+    # automatically in `cachez`.
+    def __getstate__(self):
+        state = vars(self).copy()
+        for key in ('_hlu_lock', '_self_cache_lock_', '_self_cache_'):
+            if key in state:
+                del state[key]
+        return state
+
+    def __setstate__(self, state):
+        vars(self).update(state)
+        self._hlu_lock = Lock()
+
 
 class VNXStorageGroupList(VNXCliResourceList):
     @classmethod

--- a/storops/vnx/sg_cache.py
+++ b/storops/vnx/sg_cache.py
@@ -1,0 +1,36 @@
+# coding=utf-8
+# Copyright (c) 2020 Dell Inc. or its subsidiaries.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+from __future__ import unicode_literals
+
+import persistqueue
+
+
+class SGCache(persistqueue.PDict):
+    """SGCache shares the VNX SG caching between OpenStack Cinder backends.
+
+    This shared cache is introduced to fix the issue like:
+    https://github.com/emc-openstack/storops/issues/305. The fix to storops is
+    not enough though. Because different OpenStack VNX Cinder backends for
+    two or more pools will have the dirty cache as described in issue #305.
+
+    The shared cache will persist the VNX storage groups information in the
+    same file path on the same machine via ``persistqueue.PDict``.
+    """
+
+    def __init__(self, persist_path):
+        self._persist_path = persist_path
+        super(SGCache, self).__init__(persist_path, 'storops_sg_cache',
+                                      multithreading=True)

--- a/storops_test/unity/resource/test_lun.py
+++ b/storops_test/unity/resource/test_lun.py
@@ -15,6 +15,7 @@
 #    under the License.
 from __future__ import unicode_literals
 
+import pickle
 from unittest import TestCase
 
 import ddt
@@ -574,6 +575,14 @@ class UnityLunTest(TestCase):
         lun = UnityLun(_id='sv_16455', cli=cli)
         resp = lun.remove_snap_schedule()
         assert_that(resp.is_ok(), equal_to(True))
+
+    @patch_rest
+    def test_picklable(self):
+        cli = t_rest()
+        lun = UnityLun(_id='sv_16455', cli=cli)
+        lun.update()
+        lun_new = pickle.loads(pickle.dumps(lun))
+        assert_that(lun_new.name, equal_to(lun.name))
 
 
 class UnityLunEnablePerfStatsTest(TestCase):

--- a/storops_test/vnx/cli_mock.py
+++ b/storops_test/vnx/cli_mock.py
@@ -162,6 +162,16 @@ def t_cli(version=None):
 
 
 @cache
+@patch_cli
+def t_cli_simple():
+    """get the test cli client with stats
+
+    :return: test cli client
+    """
+    return CliClient('10.244.212.182', heartbeat_interval=0)
+
+
+@cache
 def t_vnx():
     """ get the test vnx instance
 

--- a/storops_test/vnx/resource/test_sg.py
+++ b/storops_test/vnx/resource/test_sg.py
@@ -15,6 +15,7 @@
 #    under the License.
 from __future__ import unicode_literals
 
+import pickle
 from unittest import TestCase
 
 from hamcrest import assert_that, equal_to, has_item, raises, instance_of, \
@@ -29,7 +30,7 @@ from storops.vnx.enums import VNXSPEnum
 from storops.vnx.resource.lun import VNXLun
 from storops.vnx.resource.port import VNXStorageGroupHBAList
 from storops.vnx.resource.sg import VNXStorageGroupList, VNXStorageGroup
-from storops_test.vnx.cli_mock import patch_cli, t_cli
+from storops_test.vnx.cli_mock import patch_cli, t_cli, t_cli_simple
 from storops_test.vnx.resource.test_lun import get_lun_list
 
 __author__ = 'Cedric Zhuang'
@@ -459,3 +460,13 @@ class VNXStorageGroupTest(TestCase):
     @patch_cli
     def test_sg_write_size_kb(self):
         assert_that(self.sg.write_size_kb, close_to(921, 1))
+
+    @patch_cli
+    def test_picklable(self):
+        sg = VNXStorageGroup.get(t_cli_simple(), 'server7')
+        assert_that(len(sg.get_alu_hlu_map()), equal_to(2))
+        expected = sg.get_alu_hlu_map()
+        sg_str = pickle.dumps(sg)
+        sg_new = pickle.loads(sg_str)
+        assert_that(len(sg_new.get_alu_hlu_map()), equal_to(2))
+        assert_that(sg_new.get_alu_hlu_map(), equal_to(expected))

--- a/storops_test/vnx/test_enums.py
+++ b/storops_test/vnx/test_enums.py
@@ -15,6 +15,7 @@
 #    under the License.
 from __future__ import unicode_literals
 
+import pickle
 from unittest import TestCase
 
 import six
@@ -191,6 +192,9 @@ class VNXSPEnumTest(TestCase):
 
         for k, v in six.iteritems(data):
             assert_that(VNXSPEnum.parse(k), equal_to(v),
+                        'input: {}'.format(k))
+            assert_that(pickle.loads(pickle.dumps(VNXSPEnum.parse(k))) is v,
+                        equal_to(True),
                         'input: {}'.format(k))
 
     def test_get_sp_index_err(self):

--- a/storops_test/vnx/test_heart_beat.py
+++ b/storops_test/vnx/test_heart_beat.py
@@ -15,6 +15,7 @@
 #    under the License.
 from __future__ import unicode_literals
 
+import pickle
 from unittest import TestCase
 
 import time
@@ -201,6 +202,22 @@ class NodeHeartBeatTest(TestCase):
         assert_that(hb.command_count, less_than_or_equal_to(2))
         hb.stop()
         time.sleep(0.1)
+
+    def test_picklable(self):
+        hb = NodeHeartBeat(interval=0.1)
+        hb.add('spa', '1.1.1.1')
+        hb.add('spb', '1.1.1.2')
+        time.sleep(0.1)
+        hb_new = pickle.loads(pickle.dumps(hb))
+        time.sleep(0.3)
+        assert_that(hb_new._heartbeat_thread is not None, equal_to(True))
+        assert_that(len(hb_new.nodes), equal_to(len(hb.nodes)))
+        assert_that(hb_new.interval, equal_to(hb.interval))
+        assert_that(hb_new.timeout, equal_to(hb.timeout))
+        assert_that([n.ip for n in hb_new.nodes],
+                    equal_to([n.ip for n in hb.nodes]))
+        hb.stop()
+        hb_new.stop()
 
 
 class NodeInfoTest(TestCase):

--- a/storops_test/vnx/test_sg_cache.py
+++ b/storops_test/vnx/test_sg_cache.py
@@ -1,0 +1,35 @@
+# coding=utf-8
+# Copyright (c) 2020 Dell Inc. or its subsidiaries.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+from __future__ import unicode_literals
+
+import tempfile
+from unittest import TestCase
+
+from hamcrest import equal_to, assert_that
+
+from storops import SGCache
+
+
+class SGCacheTest(TestCase):
+    def test_set_and_get(self):
+        folder = tempfile.mkdtemp(suffix='storops')
+        cache = SGCache(folder)
+        cache['sg-1'] = {'abc': 'efg'}
+
+        cache_get = SGCache(folder)
+        assert_that('sg-1' in cache_get, equal_to(True))
+        assert_that('abc' in cache_get['sg-1'], equal_to(True))
+        assert_that(cache_get['sg-1']['abc'], equal_to('efg'))


### PR DESCRIPTION
Use `persist-queue.PDict` to share the cache of storage group between
differen processes running on the same machine, i.e. different OpenStack
Cinder backends.

`PDict` leverages `pickle` to serialize and deserialize Python objects.
Objects are modified to be picklable in this commit.