### PR TITLE
Use compatible pytest,pytest-xdist,pytest-cov

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,9 +2,12 @@ coverage>=4.0
 flake8>=2.2.0
 mock>=1.0.1
 PyHamcrest>=1.8.5
-pytest>=4.4.0
-pytest-cov>=2.1.0
-pytest-xdist>=1.13.1
+pytest>=4.4.0,<6.0.0;python_version<'3.6'
+pytest>=6.0.0;python_version>='3.6'
+pytest-cov>=2.1.0,<2.10.1;python_version<'3.6'
+pytest-cov>=2.10.1;python_version>='3.6'
+pytest-xdist>=1.13.1,<2.0.0;python_version<'3.6'
+pytest-xdist>=2.0.0;python_version>='3.6'
 xmltodict>=0.9.2
 fasteners>=0.12.0
 ddt>=1.0.1 # MIT


### PR DESCRIPTION
Travis py36 and py37 failed because it installed incompatible
pytest(5.4.3) and pytest-xdist(2.0.0).
https://travis-ci.com/github/emc-openstack/storops/jobs/373116173, line
251, 255 and 296.

This commit just limit the version of pytest, pytest-xdist and
pytest-cov for py36 and later.