### PR TITLE
Unity: fix fs/nfs/cifs issues

### DIFF
--- a/storops/unity/resource/cifs_share.py
+++ b/storops/unity/resource/cifs_share.py
@@ -73,7 +73,8 @@ class UnityCifsShare(UnityResource):
                               cifsShareParameters=share_param)
         resp = sr.modify_fs(cifsShareCreate=[param])
         resp.raise_if_err()
-        return UnityCifsShareList(cli=cli, name=name).first_item
+        return UnityCifsShareList(
+            cli=cli, name=name, filesystem=fs).first_item
 
     @classmethod
     def create_from_snap(cls, cli, snap, name, path=None, is_read_only=None,

--- a/storops/unity/resource/filesystem.py
+++ b/storops/unity/resource/filesystem.py
@@ -101,7 +101,7 @@ class UnityFileSystem(UnityResource):
             params['fsParameters'] = fs_param
         if cifs_fs_parameters:
             params['cifsFsParameters'] = cifs_fs_parameters
-        if description:
+        if description is not None:
             params['description'] = description
 
         if not params:

--- a/storops/unity/resource/nfs_share.py
+++ b/storops/unity/resource/nfs_share.py
@@ -173,7 +173,7 @@ class UnityNfsShare(UnityResource):
                               nfsShareParameters=share_param)
         resp = sr.modify_fs(nfsShareCreate=[param])
         resp.raise_if_err()
-        return UnityNfsShareList(cli=cli, name=name).first_item
+        return UnityNfsShareList(cli=cli, name=name, filesystem=fs).first_item
 
     @classmethod
     def create_from_snap(cls, cli, snap, name, path=None, is_read_only=None,

--- a/storops_test/unity/resource/test_cifs_share.py
+++ b/storops_test/unity/resource/test_cifs_share.py
@@ -142,11 +142,18 @@ class UnityCifsShareTest(TestCase):
         assert_that(share.description, equal_to(description))
 
     @patch_rest
-    def test_create_same_name_exists(self):
+    def test_create_same_name_exists_in_fs(self):
         def f():
             UnityCifsShare.create(t_rest(), 'cs2', 'fs_8')
 
         assert_that(f, raises(UnitySmbShareNameExistedError, 'already exists'))
+
+    @patch_rest
+    def test_create_same_name_in_diff_fs(self):
+        UnityCifsShare.create(t_rest(), 'cs1', 'fs_8')
+        share = UnityCifsShare.create(t_rest(), 'cs1', 'fs_7')
+        assert_that(share.name, equal_to('cs1'))
+        assert_that(share.filesystem.name, equal_to('fs7'))
 
     @patch_rest
     def test_modify_success(self):

--- a/storops_test/unity/resource/test_filesystem.py
+++ b/storops_test/unity/resource/test_filesystem.py
@@ -240,6 +240,12 @@ class UnityFileSystemTest(TestCase):
         fs.modify()
 
     @patch_rest
+    def test_modify_success_empty_description(self):
+        fs = UnityFileSystem(cli=t_rest(), _id='fs_22')
+        fs.modify(description='')
+        assert_that(fs.description, equal_to(''))
+
+    @patch_rest
     def test_delete_filesystem_async(self):
         fs = UnityFileSystem(_id='fs_14', cli=t_rest())
         resp = fs.delete(async_mode=True)

--- a/storops_test/unity/resource/test_nfs_share.py
+++ b/storops_test/unity/resource/test_nfs_share.py
@@ -250,13 +250,24 @@ class UnityNfsShareTest(TestCase):
         share.modify()
 
     @patch_rest
-    def test_create_nfs_share_name_exists(self):
+    def test_create_nfs_share_name_exists_in_fs(self):
         def f():
             UnityNfsShare.create(
                 t_rest(), 'ns1', 'fs_9',
                 share_access=NFSShareDefaultAccessEnum.ROOT)
 
         assert_that(f, raises(UnityNfsShareNameExistedError, 'already exists'))
+
+    @patch_rest
+    def test_create_nfs_share_same_name_in_diff_fs(self):
+        UnityNfsShare.create(
+            t_rest(), 'ns1', 'fs_9',
+            share_access=NFSShareDefaultAccessEnum.READ_WRITE)
+        share = UnityNfsShare.create(
+            t_rest(), 'ns1', 'fs_10',
+            share_access=NFSShareDefaultAccessEnum.READ_WRITE)
+        assert_that(share.name, equal_to('ns1'))
+        assert_that(share.filesystem.name, equal_to('esa_nfs1'))
 
     @patch_rest
     def test_delete_nfs_share_success(self):

--- a/storops_test/unity/rest_data/cifsShare/index.json
+++ b/storops_test/unity/rest_data/cifsShare/index.json
@@ -45,7 +45,15 @@
       "response": "name_cs1.json"
     },
     {
-      "url": "/api/types/cifsShare/instances?compact=True&fields=creationTime,description,exportPaths,filesystem,id,instanceId,isABEEnabled,isACEEnabled,isBranchCacheEnabled,isContinuousAvailabilityEnabled,isDFSEnabled,isEncryptionEnabled,isReadOnly,modifiedTime,name,offlineAvailability,path,snap,type,umask&filter=name eq \"cs61\"",
+      "url": "/api/types/cifsShare/instances?compact=True&fields=creationTime,description,exportPaths,filesystem,id,instanceId,isABEEnabled,isACEEnabled,isBranchCacheEnabled,isContinuousAvailabilityEnabled,isDFSEnabled,isEncryptionEnabled,isReadOnly,modifiedTime,name,offlineAvailability,path,snap,type,umask&filter=filesystem eq \"fs_8\" and name eq \"cs1\"",
+      "response": "name_cs1.json"
+    },
+    {
+      "url": "/api/types/cifsShare/instances?compact=True&fields=creationTime,description,exportPaths,filesystem,id,instanceId,isABEEnabled,isACEEnabled,isBranchCacheEnabled,isContinuousAvailabilityEnabled,isDFSEnabled,isEncryptionEnabled,isReadOnly,modifiedTime,name,offlineAvailability,path,snap,type,umask&filter=filesystem eq \"fs_7\" and name eq \"cs1\"",
+      "response": "name_cs1_1.json"
+    },
+    {
+      "url": "/api/types/cifsShare/instances?compact=True&fields=creationTime,description,exportPaths,filesystem,id,instanceId,isABEEnabled,isACEEnabled,isBranchCacheEnabled,isContinuousAvailabilityEnabled,isDFSEnabled,isEncryptionEnabled,isReadOnly,modifiedTime,name,offlineAvailability,path,snap,type,umask&filter=filesystem eq \"fs_61\" and name eq \"cs61\"",
       "response": "name_cs61.json"
     },
     {

--- a/storops_test/unity/rest_data/cifsShare/name_cs1_1.json
+++ b/storops_test/unity/rest_data/cifsShare/name_cs1_1.json
@@ -1,5 +1,5 @@
 {
-  "@base": "https://10.244.223.66/api/types/cifsShare/instances?filter=filesystem eq \"fs_8\" and name eq \"cs1\"&fields=creationTime,description,exportPaths,id,instanceId,isABEEnabled,isACEEnabled,isBranchCacheEnabled,isContinuousAvailabilityEnabled,isDFSEnabled,isEncryptionEnabled,isReadOnly,modifiedTime,name,offlineAvailability,path,type,umask,filesystem.id,snap.id&per_page=2000&compact=true",
+  "@base": "https://10.244.223.66/api/types/cifsShare/instances?filter=filesystem eq \"fs_7\" and name eq \"cs1\"&fields=creationTime,description,exportPaths,id,instanceId,isABEEnabled,isACEEnabled,isBranchCacheEnabled,isContinuousAvailabilityEnabled,isDFSEnabled,isEncryptionEnabled,isReadOnly,modifiedTime,name,offlineAvailability,path,type,umask,filesystem.id,snap.id&per_page=2000&compact=true",
   "updated": "2016-03-17T11:21:38.117Z",
   "links": [
     {
@@ -17,8 +17,8 @@
         "name": "cs1",
         "path": "/",
         "exportPaths": [
-          "\\\\nas1130.win2012.dev\\cs1",
-          "\\\\10.244.220.120\\cs1"
+          "\\\\nas1131.win2012.dev\\cs1",
+          "\\\\10.244.220.121\\cs1"
         ],
         "description": "",
         "creationTime": "2016-03-17T10:20:21.899Z",
@@ -31,7 +31,7 @@
         "isDFSEnabled": false,
         "umask": "022",
         "filesystem": {
-          "id": "fs_8"
+          "id": "fs_7"
         }
       }
     }

--- a/storops_test/unity/rest_data/cifsShare/name_cs61.json
+++ b/storops_test/unity/rest_data/cifsShare/name_cs61.json
@@ -1,5 +1,5 @@
 {
-  "@base": "https://192.168.1.58/api/types/cifsShare/instances?filter=name eq \"cs61\"&fields=creationTime,description,exportPaths,filesystem,id,instanceId,isABEEnabled,isACEEnabled,isBranchCacheEnabled,isContinuousAvailabilityEnabled,isDFSEnabled,isEncryptionEnabled,isReadOnly,modifiedTime,name,offlineAvailability,path,snap,type,umask&per_page=2000&compact=true",
+  "@base": "https://192.168.1.58/api/types/cifsShare/instances?filter=filesystem eq \"fs_61\" and name eq \"cs61\"&fields=creationTime,description,exportPaths,filesystem,id,instanceId,isABEEnabled,isACEEnabled,isBranchCacheEnabled,isContinuousAvailabilityEnabled,isDFSEnabled,isEncryptionEnabled,isReadOnly,modifiedTime,name,offlineAvailability,path,snap,type,umask&per_page=2000&compact=true",
   "updated": "2020-10-29T05:50:45.531Z",
   "links": [
     {

--- a/storops_test/unity/rest_data/filesystem/fs_22.json
+++ b/storops_test/unity/rest_data/filesystem/fs_22.json
@@ -1,0 +1,77 @@
+{
+  "content": {
+    "id": "fs_22",
+    "operationalStatus": [
+      2
+    ],
+    "type": 1,
+    "tieringPolicy": 3,
+    "supportedProtocols": 0,
+    "accessPolicy": 1,
+    "folderRenamePolicy": 1,
+    "lockingPolicy": 1,
+    "format": 2,
+    "hostIOSize": 8192,
+    "poolFullPolicy": 0,
+    "instanceId": "root/emc:EMC_UEM_FileSystemLeaf%InstanceID=fs_13",
+    "health": {
+      "value": 5,
+      "descriptionIds": [
+        "ALRT_APP_FS_OK"
+      ],
+      "descriptions": [
+        "This storage resource is operating normally. No action is required."
+      ]
+    },
+    "name": "fs22",
+    "description": "",
+    "creationTime": "2016-03-02T02:43:33.495Z",
+    "modificationTime": "2016-03-02T02:43:33.496Z",
+    "sizeTotal": 5368709120,
+    "sizeUsed": 1642971136,
+    "sizeAllocated": 3221225472,
+    "sizePreallocated": 2401206272,
+    "sizeAllocatedTotal": 4578115584,
+    "minSizeAllocated": 0,
+    "isReadOnly": false,
+    "isThinEnabled": true,
+    "isDataReductionEnabled": false,
+    "dataReductionSizeSaved": 0,
+    "dataReductionPercent": 0,
+    "dataReductionRatio": 1.0,
+    "isAdvancedDedupEnabled": false,
+    "isCIFSSyncWritesEnabled": true,
+    "isCIFSOpLocksEnabled": true,
+    "isCIFSNotifyOnWriteEnabled": true,
+    "isCIFSNotifyOnAccessEnabled": true,
+    "cifsNotifyOnChangeDirDepth": 256,
+    "cifsNumUsedFiles": 0,
+    "oid": 8589934602,
+    "backendId": "171798691846",
+    "metadataSize": 3489660928,
+    "metadataSizeAllocated": 3221225472,
+    "perTierSizeUsed": [
+      6442450944,
+      0,
+      0
+    ],
+    "snapsSize": 0,
+    "snapsSizeAllocated": 0,
+    "snapCount": 0,
+    "isSMBCA": false,
+    "storageResource": {
+      "id": "res_22"
+    },
+    "pool": {
+      "id": "pool_1"
+    },
+    "nasServer": {
+      "id": "nas_1"
+    },
+    "cifsShare": [
+      {
+        "id": "SMBShare_1"
+      }
+    ]
+  }
+}

--- a/storops_test/unity/rest_data/filesystem/fs_7.json
+++ b/storops_test/unity/rest_data/filesystem/fs_7.json
@@ -1,0 +1,81 @@
+{
+  "content": {
+    "id": "fs_7",
+    "operationalStatus": [
+      2
+    ],
+    "type": 1,
+    "dedupState": 2,
+    "tieringPolicy": 0,
+    "supportedProtocols": 1,
+    "accessPolicy": 2,
+    "renamePolicy": 0,
+    "lockingPolicy": 0,
+    "format": 2,
+    "hostIOSize": 8192,
+    "poolFullPolicy": 0,
+    "instanceId": "root/emc:EMC_UEM_FileSystemLeaf%InstanceID=fs_7",
+    "health": {
+      "value": 5,
+      "descriptionIds": [
+        "ALRT_APP_FS_OK"
+      ],
+      "descriptions": [
+        "This storage resource is operating normally. No action is required."
+      ]
+    },
+    "name": "fs7",
+    "description": "",
+    "creationTime": "2016-03-17T10:00:06.089Z",
+    "modificationTime": "2016-03-17T10:00:06.097Z",
+    "sizeTotal": 3221225472,
+    "sizeUsed": 1620303872,
+    "sizeAllocated": 3221225472,
+    "isReadOnly": false,
+    "isThinEnabled": true,
+    "isCIFSSyncWritesEnabled": false,
+    "isCIFSOpLocksEnabled": true,
+    "isCIFSNotifyOnWriteEnabled": false,
+    "isCIFSNotifyOnAccessEnabled": false,
+    "cifsNotifyOnChangeDirDepth": 512,
+    "cifsNumUsedFiles": 0,
+    "dedupExcludePaths": [
+      ""
+    ],
+    "dedupExcludeExtensions": [
+      ""
+    ],
+    "isDedupRunning": false,
+    "dedupOriginalSizeUsed": 1351819264,
+    "dedupSizeUsed": 0,
+    "dedupSizeSaved": 0,
+    "dedupPercentSaved": 0,
+    "dedupNumFilesTotal": 0,
+    "dedupNumFilesDeduped": 0,
+    "dedupNumFilesScanned": 0,
+    "dedupNumFileRecalled": 0,
+    "dedupProgress": 100,
+    "oid": 8589934637,
+    "backendId": "171798691864",
+    "metadataSize": 3489660928,
+    "metadataSizeAllocated": 3221225472,
+    "perTierSizeUsed": [
+      0,
+      6442450944,
+      0
+    ],
+    "snapsSize": 0,
+    "snapsSizeAllocated": 0,
+    "snapCount": 0,
+    "isSMBCA": false,
+    "storageResource": {
+      "id": "res_23"
+    },
+    "pool": {
+      "id": "pool_2"
+    },
+    "nasServer": {
+      "id": "nas_2"
+    }
+  }
+}

--- a/storops_test/unity/rest_data/filesystem/index.json
+++ b/storops_test/unity/rest_data/filesystem/index.json
@@ -21,6 +21,10 @@
       "response": "fs_5.json"
     },
     {
+      "url": "/api/instances/filesystem/fs_7?compact=True&fields=accessPolicy,backendId,cifsNotifyOnChangeDirDepth,cifsNumUsedFiles,cifsShare,creationTime,description,format,health,hostIOSize,id,instanceId,isCIFSNotifyOnAccessEnabled,isCIFSNotifyOnWriteEnabled,isCIFSOpLocksEnabled,isCIFSSyncWritesEnabled,isReadOnly,isSMBCA,isThinEnabled,lockingPolicy,metadataSize,metadataSizeAllocated,modificationTime,name,nasServer,nfsShare,oid,operationalStatus,perTierSizeUsed,pool,poolFullPolicy,renamePolicy,sizeAllocated,sizeTotal,sizeUsed,snapCount,snapsSize,snapsSizeAllocated,storageResource,supportedProtocols,tieringPolicy,tieringPolicy,type",
+      "response": "fs_7.json"
+    },
+    {
       "url": "/api/instances/filesystem/fs_8?compact=True&fields=accessPolicy,backendId,cifsNotifyOnChangeDirDepth,cifsNumUsedFiles,cifsShare,creationTime,description,format,health,hostIOSize,id,instanceId,isCIFSNotifyOnAccessEnabled,isCIFSNotifyOnWriteEnabled,isCIFSOpLocksEnabled,isCIFSSyncWritesEnabled,isReadOnly,isSMBCA,isThinEnabled,lockingPolicy,metadataSize,metadataSizeAllocated,modificationTime,name,nasServer,nfsShare,oid,operationalStatus,perTierSizeUsed,pool,poolFullPolicy,renamePolicy,sizeAllocated,sizeTotal,sizeUsed,snapCount,snapsSize,snapsSizeAllocated,storageResource,supportedProtocols,tieringPolicy,tieringPolicy,type",
       "response": "fs_8.json"
     },
@@ -59,6 +63,10 @@
     {
       "url": "/api/instances/filesystem/fs_21?compact=True&fields=accessPolicy,backendId,cifsNotifyOnChangeDirDepth,cifsNumUsedFiles,cifsShare,creationTime,description,format,health,hostIOSize,id,instanceId,isCIFSNotifyOnAccessEnabled,isCIFSNotifyOnWriteEnabled,isCIFSOpLocksEnabled,isCIFSSyncWritesEnabled,isReadOnly,isSMBCA,isThinEnabled,lockingPolicy,metadataSize,metadataSizeAllocated,modificationTime,name,nasServer,nfsShare,oid,operationalStatus,perTierSizeUsed,pool,poolFullPolicy,renamePolicy,sizeAllocated,sizeTotal,sizeUsed,snapCount,snapsSize,snapsSizeAllocated,storageResource,supportedProtocols,tieringPolicy,tieringPolicy,type",
       "response": "fs_21.json"
+    },
+    {
+      "url": "/api/instances/filesystem/fs_22?compact=True&fields=accessPolicy,backendId,cifsNotifyOnChangeDirDepth,cifsNumUsedFiles,cifsShare,creationTime,description,format,health,hostIOSize,id,instanceId,isCIFSNotifyOnAccessEnabled,isCIFSNotifyOnWriteEnabled,isCIFSOpLocksEnabled,isCIFSSyncWritesEnabled,isReadOnly,isSMBCA,isThinEnabled,lockingPolicy,metadataSize,metadataSizeAllocated,modificationTime,name,nasServer,nfsShare,oid,operationalStatus,perTierSizeUsed,pool,poolFullPolicy,renamePolicy,sizeAllocated,sizeTotal,sizeUsed,snapCount,snapsSize,snapsSizeAllocated,storageResource,supportedProtocols,tieringPolicy,tieringPolicy,type",
+      "response": "fs_22.json"
     },
     {
       "url": "/api/instances/filesystem/fs_41?compact=True&fields=accessPolicy,backendId,cifsNotifyOnChangeDirDepth,cifsNumUsedFiles,cifsShare,creationTime,description,format,health,hostIOSize,id,instanceId,isCIFSNotifyOnAccessEnabled,isCIFSNotifyOnWriteEnabled,isCIFSOpLocksEnabled,isCIFSSyncWritesEnabled,isReadOnly,isSMBCA,isThinEnabled,lockingPolicy,metadataSize,metadataSizeAllocated,modificationTime,name,nasServer,nfsShare,oid,operationalStatus,perTierSizeUsed,pool,poolFullPolicy,renamePolicy,sizeAllocated,sizeTotal,sizeUsed,snapCount,snapsSize,snapsSizeAllocated,storageResource,supportedProtocols,tieringPolicy,tieringPolicy,type",

--- a/storops_test/unity/rest_data/nfsShare/index.json
+++ b/storops_test/unity/rest_data/nfsShare/index.json
@@ -61,11 +61,15 @@
       "response": "all.json"
     },
     {
-      "url": "/api/types/nfsShare/instances?compact=True&fields=creationTime,defaultAccess,description,exportPaths,filesystem,hostAccesses,id,instanceId,isReadOnly,minSecurity,modificationTime,name,noAccessHosts,path,readOnlyHosts,readWriteHosts,role,rootAccessHosts,snap,type&filter=name eq \"ns1\"",
+      "url": "/api/types/nfsShare/instances?compact=True&fields=creationTime,defaultAccess,description,exportPaths,filesystem,hostAccesses,id,instanceId,isReadOnly,minSecurity,modificationTime,name,noAccessHosts,path,readOnlyHosts,readWriteHosts,role,rootAccessHosts,snap,type&filter=filesystem eq \"fs_9\" and name eq \"ns1\"",
       "response": "name_ns1.json"
     },
     {
-      "url": "/api/types/nfsShare/instances?compact=True&fields=creationTime,defaultAccess,description,exportPaths,filesystem,hostAccesses,id,instanceId,isReadOnly,minSecurity,modificationTime,name,noAccessHosts,path,readOnlyHosts,readWriteHosts,role,rootAccessHosts,snap,type&filter=name eq \"ns41\"",
+      "url": "/api/types/nfsShare/instances?compact=True&fields=creationTime,defaultAccess,description,exportPaths,filesystem,hostAccesses,id,instanceId,isReadOnly,minSecurity,modificationTime,name,noAccessHosts,path,readOnlyHosts,readWriteHosts,role,rootAccessHosts,snap,type&filter=filesystem eq \"fs_10\" and name eq \"ns1\"",
+      "response": "name_ns1_1.json"
+    },
+    {
+      "url": "/api/types/nfsShare/instances?compact=True&fields=creationTime,defaultAccess,description,exportPaths,filesystem,hostAccesses,id,instanceId,isReadOnly,minSecurity,modificationTime,name,noAccessHosts,path,readOnlyHosts,readWriteHosts,role,rootAccessHosts,snap,type&filter=filesystem eq \"fs_41\" and name eq \"ns41\"",
       "response": "name_ns41.json"
     },
     {

--- a/storops_test/unity/rest_data/nfsShare/name_ns1.json
+++ b/storops_test/unity/rest_data/nfsShare/name_ns1.json
@@ -1,5 +1,5 @@
 {
-  "@base": "https://10.244.223.66/api/types/nfsShare/instances?filter=name eq \"ns1\"&fields=creationTime,defaultAccess,description,exportPaths,id,instanceId,isReadOnly,minSecurity,modificationTime,name,path,role,type,hostAccesses.id,readOnlyHosts.id,noAccessHosts.id,rootAccessHosts.id,filesystem.id,readWriteHosts.id,snap.id&per_page=2000&compact=true",
+  "@base": "https://10.244.223.66/api/types/nfsShare/instances?filter=filesystem eq \"fs_9\" and name eq \"ns1\"&fields=creationTime,defaultAccess,description,exportPaths,id,instanceId,isReadOnly,minSecurity,modificationTime,name,path,role,type,hostAccesses.id,readOnlyHosts.id,noAccessHosts.id,rootAccessHosts.id,filesystem.id,readWriteHosts.id,snap.id&per_page=2000&compact=true",
   "updated": "2016-03-17T15:34:02.124Z",
   "links": [
     {

--- a/storops_test/unity/rest_data/nfsShare/name_ns1_1.json
+++ b/storops_test/unity/rest_data/nfsShare/name_ns1_1.json
@@ -1,0 +1,33 @@
+{
+  "@base": "https://10.244.223.66/api/types/nfsShare/instances?filter=filesystem eq \"fs_10\" and name eq \"ns1\"&fields=creationTime,defaultAccess,description,exportPaths,id,instanceId,isReadOnly,minSecurity,modificationTime,name,path,role,type,hostAccesses.id,readOnlyHosts.id,noAccessHosts.id,rootAccessHosts.id,filesystem.id,readWriteHosts.id,snap.id&per_page=2000&compact=true",
+  "updated": "2016-03-17T15:34:02.124Z",
+  "links": [
+    {
+      "rel": "self",
+      "href": "&page=1"
+    }
+  ],
+  "entries": [
+    {
+      "content": {
+        "id": "NFSShare_5",
+        "type": 1,
+        "role": 0,
+        "defaultAccess": 2,
+        "minSecurity": 0,
+        "instanceId": "root/emc:EMC_UEM_NFSShareLeaf%InstanceID=NFSShare_5",
+        "name": "ns1",
+        "path": "/",
+        "exportPaths": [
+          "10.244.220.121:/ns1"
+        ],
+        "description": "",
+        "creationTime": "2016-03-17T15:34:00.749Z",
+        "modificationTime": "2016-03-17T15:34:00.749Z",
+        "filesystem": {
+          "id": "fs_10"
+        }
+      }
+    }
+  ]
+}

--- a/storops_test/unity/rest_data/nfsShare/name_ns41.json
+++ b/storops_test/unity/rest_data/nfsShare/name_ns41.json
@@ -1,5 +1,5 @@
 {
-  "@base": "https://10.245.83.44/api/types/nfsShare/instances?filter=name eq \"ns41\"&fields=anonymousGID,anonymousUID,creationTime,defaultAccess,description,exportOption,exportPaths,filesystem,hostAccesses,id,instanceId,isReadOnly,minSecurity,modificationTime,name,nfsOwnerUsername,noAccessHosts,noAccessHostsString,path,readOnlyHosts,readOnlyHostsString,readOnlyRootAccessHosts,readOnlyRootHostsString,readWriteHosts,readWriteHostsString,readWriteRootHostsString,role,rootAccessHosts,snap,type&per_page=2000&compact=true",
+  "@base": "https://10.245.83.44/api/types/nfsShare/instances?filter=filesystem eq \"fs_41\" and name eq \"ns41\"&fields=anonymousGID,anonymousUID,creationTime,defaultAccess,description,exportOption,exportPaths,filesystem,hostAccesses,id,instanceId,isReadOnly,minSecurity,modificationTime,name,nfsOwnerUsername,noAccessHosts,noAccessHostsString,path,readOnlyHosts,readOnlyHostsString,readOnlyRootAccessHosts,readOnlyRootHostsString,readWriteHosts,readWriteHostsString,readWriteRootHostsString,role,rootAccessHosts,snap,type&per_page=2000&compact=true",
   "updated": "2020-10-27T07:52:39.220Z",
   "links": [
     {

--- a/storops_test/unity/rest_data/storageResource/index.json
+++ b/storops_test/unity/rest_data/storageResource/index.json
@@ -151,6 +151,13 @@
       "response": "empty.json"
     },
     {
+      "url": "/api/instances/storageResource/res_22/action/modifyFilesystem?compact=True",
+      "body": {
+        "description": ""
+      },
+      "response": "empty.json"
+    },
+    {
       "url": "/api/instances/storageResource/res_23/action/modifyFilesystem?compact=True",
       "body": {
         "cifsShareCreate": [
@@ -222,6 +229,21 @@
     },
     {
       "url": "/api/instances/storageResource/res_24/action/modifyFilesystem?compact=True",
+      "body": {
+        "nfsShareCreate": [
+          {
+            "path": "/",
+            "name": "ns1",
+            "nfsShareParameters": {
+              "defaultAccess": 2
+            }
+          }
+        ]
+      },
+      "response": "empty.json"
+    },
+    {
+      "url": "/api/instances/storageResource/res_25/action/modifyFilesystem?compact=True",
       "body": {
         "nfsShareCreate": [
           {


### PR DESCRIPTION
Fix filesystem, nfs share, cifs share issues:

- Incorrect response from nfs_share create() call
- Unable to remove filesystem's description