### PR TITLE
urllib3 needs to be > 2.4.0 for security issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ python-dateutil>=2.4.2 # BSD
 retryz>=0.1.8 # Apache-2.0
 cachez>=0.1.0 # Apache-2.0
 bitmath>=1.3.0 # MIT
+urllib3>=2.5.0 # MIT


### PR DESCRIPTION
- Make sure urllib3 > 2.4.0 to fix dependency security vulnerabilities 